### PR TITLE
Fix incorrect APP_PUBLIC_PATH fallback in worker

### DIFF
--- a/public/worker.php
+++ b/public/worker.php
@@ -1,7 +1,7 @@
 <?php
 
 $_SERVER['APP_BASE_PATH'] = $_ENV['APP_BASE_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__.'/..';
-$_SERVER['APP_PUBLIC_PATH'] = $_ENV['APP_PUBLIC_PATH'] ?? $_SERVER['APP_BASE_PATH'] ?? __DIR__;
+$_SERVER['APP_PUBLIC_PATH'] = $_ENV['APP_PUBLIC_PATH'] ?? $_SERVER['APP_PUBLIC_PATH'] ?? __DIR__;
 
 // Make sure you have installed Laravel Octane
 require __DIR__.'/../vendor/laravel/octane/bin/frankenphp-worker.php';


### PR DESCRIPTION
## Summary
- ensure worker respects APP_PUBLIC_PATH when set

## Testing
- `php -l public/worker.php`


------
https://chatgpt.com/codex/tasks/task_e_689abb126f94832e8a490ce6f2adece3