### PR TITLE
docs: specify viewing the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Install dependencies and prepare framework:
 
 > **Note**: The `./` at the beginning of each command is an alias to `docker compose exec php`, allowing you to run commands within the container without entering it.
 
-You're done! Open https://laravel.docker.localhost to view application.
+You're done! Open https://laravel.docker.localhost to view the application.


### PR DESCRIPTION
## Summary
- clarify README URL instructions to explicitly mention the application

## Testing
- `npm test` (fails: could not read package.json)
- `./composer test` (fails: docker: not found)


------
https://chatgpt.com/codex/tasks/task_e_689abcb9abb4832eb125d42f35691137