### PR TITLE
docs: add Octane prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ To use it:
 - Copy all files and folders from this repository into the root of your existing Laravel project.
 - Follow the steps below to set up Docker, generate SSL certificates, and start your Laravel Octane app in seconds.
 
+## Prerequisites
+
+Install Laravel Octane into your project:
+
+```shell
+composer require laravel/octane
+```
+
 ## Docker Setup Guide
 
 ### Step 1: Copy to your Laravel Project


### PR DESCRIPTION
## Summary
- document `composer require laravel/octane` prerequisite before the Docker setup guide

## Testing
- `npm test` *(fails: no package.json)*
- `composer validate` *(fails: composer.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3000ebcc832eb47dc2f89e8c32fd