### PR TITLE
feat: enhance Docker Compose support and error handling

### DIFF
--- a/src/Console/Concerns/ChecksDocker.php
+++ b/src/Console/Concerns/ChecksDocker.php
@@ -23,9 +23,87 @@ trait ChecksDocker
      */
     protected function checkDockerCompose(): bool
     {
+        // Try 'docker compose' first (Docker Compose V2)
         exec('docker compose version', $output, $returnCode);
-        $output = $output ?? [];
+        if ($returnCode === 0) {
+            return true;
+        }
+        // Fallback to 'docker-compose' (Docker Compose V1)
+        exec('docker-compose version', $output, $returnCode);
         return $returnCode === 0;
+    }
+
+    /**
+     * Get the available Docker Compose command.
+     *
+     * Returns 'docker compose' if available (V2), otherwise 'docker-compose' (V1).
+     *
+     * @return string
+     */
+    protected function getDockerComposeCommand(): string
+    {
+        exec('docker compose version', $output, $returnCode);
+        if ($returnCode === 0) {
+            return 'docker compose';
+        }
+        return 'docker-compose';
+    }
+
+    /**
+     * Resolve the Docker Compose file path.
+     *
+     * If a custom file is provided via -f/--file, it will be used.
+     * Otherwise, attempts to find docker-compose.{environment}.yml.
+     * If the default file doesn't exist and no custom file is provided,
+     * prompts the user to specify one using the -f flag.
+     *
+     * @param string $environment The environment (development|production)
+     * @param string|null $customFile Custom compose file path from -f option
+     * @return string|false The resolved compose file path, or false on failure
+     */
+    protected function resolveComposeFile(string $environment, ?string $customFile): string|false
+    {
+        // If custom file is provided, use it (resolve relative to base_path if not absolute)
+        if ($customFile !== null && $customFile !== '') {
+            if (str_starts_with($customFile, '/')) {
+                return $customFile;
+            }
+            return base_path($customFile);
+        }
+
+        // Try default compose file for the environment
+        $defaultFile = base_path("docker-compose.{$environment}.yml");
+        
+        if (file_exists($defaultFile)) {
+            return $defaultFile;
+        }
+
+        // Default file doesn't exist, show helpful error message
+        $this->newLine();
+        $this->error("✗ Docker Compose file not found: docker-compose.{$environment}.yml");
+        $this->newLine();
+        $this->line('The default compose file has been removed or renamed.');
+        $this->line('You can either:');
+        $this->newLine();
+        $this->line('  1. Republish the default compose files:');
+        $this->comment('     php artisan vendor:publish --tag=laradox-docker');
+        $this->newLine();
+        $this->line('  2. Use a custom compose file with the -f option:');
+        $this->comment("     php artisan laradox:up -f docker-compose.yml");
+        $this->comment("     php artisan laradox:up -f my-custom-compose.yml");
+        $this->newLine();
+        
+        // Check if any docker-compose*.yml files exist
+        $existingFiles = glob(base_path('docker-compose*.yml'));
+        if (!empty($existingFiles)) {
+            $this->line('  Available compose files in your project:');
+            foreach ($existingFiles as $file) {
+                $this->comment('     ' . basename($file));
+            }
+            $this->newLine();
+        }
+
+        return false;
     }
 
     /**
@@ -431,8 +509,10 @@ trait ChecksDocker
      */
     protected function areContainersRunning(string $composeFile): bool
     {
+        $dockerCompose = $this->getDockerComposeCommand();
         $command = sprintf(
-            'docker compose -f %s ps --quiet 2>/dev/null',
+            '%s -f %s ps --quiet 2>/dev/null',
+            $dockerCompose,
             escapeshellarg($composeFile)
         );
 
@@ -449,8 +529,10 @@ trait ChecksDocker
      */
     protected function getAvailableServices(string $composeFile): array
     {
+        $dockerCompose = $this->getDockerComposeCommand();
         $command = sprintf(
-            'docker compose -f %s config --services 2>/dev/null',
+            '%s -f %s config --services 2>/dev/null',
+            $dockerCompose,
             escapeshellarg($composeFile)
         );
 

--- a/src/Console/DownCommand.php
+++ b/src/Console/DownCommand.php
@@ -14,6 +14,7 @@ class DownCommand extends Command
      * @var string
      */
     protected $signature = 'laradox:down 
+                            {--f|file= : Custom Docker Compose file path}
                             {--environment=development : Environment (development|production)}
                             {--volumes : Remove named volumes}';
 
@@ -45,17 +46,26 @@ class DownCommand extends Command
         }
 
         $env = $this->option('environment');
-        $composeFile = base_path("docker-compose.{$env}.yml");
+        $customFile = $this->option('file');
+        
+        // Determine compose file path
+        $composeFile = $this->resolveComposeFile($env, $customFile);
+        if ($composeFile === false) {
+            return self::FAILURE;
+        }
 
         if (!file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
             return self::FAILURE;
         }
 
-        $this->info("Stopping Laradox ({$env} environment)...");
+        $composeFileName = basename($composeFile);
+        $this->info("Stopping Laradox using {$composeFileName}...");
 
+        $dockerCompose = $this->getDockerComposeCommand();
         $command = sprintf(
-            'docker compose -f %s down',
+            '%s -f %s down',
+            $dockerCompose,
             escapeshellarg($composeFile)
         );
 

--- a/src/Console/LogsCommand.php
+++ b/src/Console/LogsCommand.php
@@ -15,6 +15,7 @@ class LogsCommand extends Command
      */
     protected $signature = 'laradox:logs 
                             {service? : Service name (nginx, php, node, scheduler, queue)}
+                            {--file= : Custom Docker Compose file path}
                             {--environment=development : Environment (development|production)}
                             {--f|follow : Follow log output}
                             {--tail= : Number of lines to show from the end of the logs}
@@ -35,7 +36,13 @@ class LogsCommand extends Command
     public function handle(): int
     {
         $env = $this->option('environment');
-        $composeFile = base_path("docker-compose.{$env}.yml");
+        $customFile = $this->option('file');
+        
+        // Determine compose file path
+        $composeFile = $this->resolveComposeFile($env, $customFile);
+        if ($composeFile === false) {
+            return self::FAILURE;
+        }
 
         if (!file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
@@ -68,8 +75,10 @@ class LogsCommand extends Command
         }
 
         // Build the logs command
+        $dockerCompose = $this->getDockerComposeCommand();
         $command = sprintf(
-            'docker compose -f %s logs',
+            '%s -f %s logs',
+            $dockerCompose,
             escapeshellarg($composeFile)
         );
 

--- a/src/Console/ShellCommand.php
+++ b/src/Console/ShellCommand.php
@@ -15,6 +15,7 @@ class ShellCommand extends Command
      */
     protected $signature = 'laradox:shell 
                             {service=php : Service name (nginx, php, node, scheduler, queue)}
+                            {--f|file= : Custom Docker Compose file path}
                             {--environment=development : Environment (development|production)}
                             {--user= : User to run the shell as}
                             {--shell=sh : Shell to use (sh, bash, zsh)}';
@@ -49,7 +50,13 @@ class ShellCommand extends Command
         }
 
         $env = $this->option('environment');
-        $composeFile = base_path("docker-compose.{$env}.yml");
+        $customFile = $this->option('file');
+        
+        // Determine compose file path
+        $composeFile = $this->resolveComposeFile($env, $customFile);
+        if ($composeFile === false) {
+            return self::FAILURE;
+        }
 
         if (!file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
@@ -98,8 +105,10 @@ class ShellCommand extends Command
         }
 
         // Build the shell command
+        $dockerCompose = $this->getDockerComposeCommand();
         $command = sprintf(
-            'docker compose -f %s exec',
+            '%s -f %s exec',
+            $dockerCompose,
             escapeshellarg($composeFile)
         );
 
@@ -132,8 +141,10 @@ class ShellCommand extends Command
      */
     protected function isServiceRunning(string $composeFile, string $service): bool
     {
+        $dockerCompose = $this->getDockerComposeCommand();
         $command = sprintf(
-            'docker compose -f %s ps --services --filter "status=running" 2>/dev/null',
+            '%s -f %s ps --services --filter "status=running" 2>/dev/null',
+            $dockerCompose,
             escapeshellarg($composeFile)
         );
 
@@ -162,10 +173,13 @@ class ShellCommand extends Command
             $shellsToTry[] = 'bash';
         }
 
+        $dockerCompose = $this->getDockerComposeCommand();
+
         foreach ($shellsToTry as $shell) {
             // Use POSIX-safe 'command -v' instead of 'which' for portability
             $testCommand = sprintf(
-                'docker compose -f %s exec -T %s sh -lc "command -v %s" 2>/dev/null',
+                '%s -f %s exec -T %s sh -lc "command -v %s" 2>/dev/null',
+                $dockerCompose,
                 escapeshellarg($composeFile),
                 escapeshellarg($service),
                 escapeshellarg($shell)

--- a/src/Console/UpCommand.php
+++ b/src/Console/UpCommand.php
@@ -14,6 +14,7 @@ class UpCommand extends Command
      * @var string
      */
     protected $signature = 'laradox:up 
+                            {--f|file= : Custom Docker Compose file path}
                             {--environment=development : Environment (development|production)}
                             {--d|detach : Run in detached mode}
                             {--build : Build images before starting}
@@ -54,7 +55,13 @@ class UpCommand extends Command
         }
 
         $env = $this->option('environment');
-        $composeFile = base_path("docker-compose.{$env}.yml");
+        $customFile = $this->option('file');
+        
+        // Determine compose file path
+        $composeFile = $this->resolveComposeFile($env, $customFile);
+        if ($composeFile === false) {
+            return self::FAILURE;
+        }
 
         if (!file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
@@ -98,7 +105,8 @@ class UpCommand extends Command
             }
             
             $this->info('Restarting containers...');
-            $restartCommand = sprintf('docker compose -f %s restart', escapeshellarg($composeFile));
+            $dockerCompose = $this->getDockerComposeCommand();
+            $restartCommand = sprintf('%s -f %s restart', $dockerCompose, escapeshellarg($composeFile));
             passthru($restartCommand, $returnCode);
             
             if ($returnCode === 0) {
@@ -112,10 +120,13 @@ class UpCommand extends Command
             return $returnCode === 0 ? self::SUCCESS : self::FAILURE;
         }
 
-        $this->info("Starting Laradox ({$env} environment)...");
+        $composeFileName = basename($composeFile);
+        $this->info("Starting Laradox using {$composeFileName}...");
 
+        $dockerCompose = $this->getDockerComposeCommand();
         $command = sprintf(
-            'docker compose -f %s up',
+            '%s -f %s up',
+            $dockerCompose,
             escapeshellarg($composeFile)
         );
 

--- a/stubs/docker-compose.development.yml
+++ b/stubs/docker-compose.development.yml
@@ -52,7 +52,7 @@ services:
   php:
     <<: *php
     environment:
-      - SERVER_NAME=:${LARADOX_FRANKENPHP_PORT:-8080}
+      - LARADOX_FRANKENPHP_PORT=:${LARADOX_FRANKENPHP_PORT:-8080}
     healthcheck:
       test: ["CMD", "php", "-v"]
       interval: 30s

--- a/stubs/docker-compose.production.yml
+++ b/stubs/docker-compose.production.yml
@@ -42,7 +42,7 @@ services:
   php:
     <<: [*php, *logging]
     environment:
-      - SERVER_NAME=:${LARADOX_FRANKENPHP_PORT:-8080}
+      - LARADOX_FRANKENPHP_PORT=:${LARADOX_FRANKENPHP_PORT:-8080}
     healthcheck:
       test: ["CMD", "php", "-v"]
       interval: 30s

--- a/stubs/docker/php/php.dockerfile
+++ b/stubs/docker/php/php.dockerfile
@@ -1,4 +1,5 @@
 ARG ENVIRONMENT=development
+ARG LARADOX_FRANKENPHP_PORT=8080
 
 # STAGE 1: Builder
 FROM dunglas/frankenphp:1.7-php8.4-alpine AS builder
@@ -98,9 +99,9 @@ RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 FROM ${ENVIRONMENT}
 ARG ENVIRONMENT
 CMD if [ "$ENVIRONMENT" = "production" ]; then \
-        php artisan octane:frankenphp; \
+        php artisan octane:frankenphp --port=${LARADOX_FRANKENPHP_PORT}; \
     else \
-        php artisan octane:frankenphp --watch; \
+        php artisan octane:frankenphp --watch --port=${LARADOX_FRANKENPHP_PORT}; \
     fi
 WORKDIR /srv
 USER appuser

--- a/tests/Feature/DownCommandTest.php
+++ b/tests/Feature/DownCommandTest.php
@@ -12,7 +12,7 @@ class DownCommandTest extends FeatureTestCase
     public function it_fails_when_docker_compose_file_not_found(): void
     {
         $this->artisan('laradox:down')
-            ->expectsOutput('Docker Compose file not found: ' . base_path('docker-compose.development.yml'))
+            ->expectsOutput('✗ Docker Compose file not found: docker-compose.development.yml')
             ->assertExitCode(1);
     }
 
@@ -44,7 +44,7 @@ class DownCommandTest extends FeatureTestCase
         // We can't actually test docker compose execution in unit tests,
         // but we can verify the command accepts the option
         $this->artisan('laradox:down', ['--volumes' => true])
-            ->expectsOutput('Stopping Laradox (development environment)...');
+            ->expectsOutput('Stopping Laradox using docker-compose.development.yml...');
     }
 
     #[Test]
@@ -53,7 +53,7 @@ class DownCommandTest extends FeatureTestCase
         $this->createTestDockerComposeFile();
 
         $this->artisan('laradox:down')
-            ->expectsOutput('Stopping Laradox (development environment)...');
+            ->expectsOutput('Stopping Laradox using docker-compose.development.yml...');
     }
 
     #[Test]
@@ -71,7 +71,7 @@ class DownCommandTest extends FeatureTestCase
         $this->createTestDockerComposeFile('production');
 
         $this->artisan('laradox:down', ['--environment' => 'production'])
-            ->expectsOutput('Stopping Laradox (production environment)...');
+            ->expectsOutput('Stopping Laradox using docker-compose.production.yml...');
     }
 
     #[Test]

--- a/tests/Feature/LogsCommandTest.php
+++ b/tests/Feature/LogsCommandTest.php
@@ -12,7 +12,7 @@ class LogsCommandTest extends FeatureTestCase
     public function it_fails_when_docker_compose_file_not_found(): void
     {
         $this->artisan('laradox:logs')
-            ->expectsOutput('Docker Compose file not found: ' . base_path('docker-compose.development.yml'))
+            ->expectsOutput('✗ Docker Compose file not found: docker-compose.development.yml')
             ->assertExitCode(1);
     }
 
@@ -142,7 +142,7 @@ class LogsCommandTest extends FeatureTestCase
         // No compose file created
 
         $this->artisan('laradox:logs')
-            ->expectsOutput('Docker Compose file not found: ' . base_path('docker-compose.development.yml'))
+            ->expectsOutput('✗ Docker Compose file not found: docker-compose.development.yml')
             ->assertExitCode(1);
     }
 

--- a/tests/Feature/ShellCommandTest.php
+++ b/tests/Feature/ShellCommandTest.php
@@ -12,7 +12,7 @@ class ShellCommandTest extends FeatureTestCase
     public function it_fails_when_docker_compose_file_not_found(): void
     {
         $this->artisan('laradox:shell')
-            ->expectsOutput('Docker Compose file not found: ' . base_path('docker-compose.development.yml'))
+            ->expectsOutput('✗ Docker Compose file not found: docker-compose.development.yml')
             ->assertExitCode(1);
     }
 

--- a/tests/Feature/UpCommandTest.php
+++ b/tests/Feature/UpCommandTest.php
@@ -12,7 +12,7 @@ class UpCommandTest extends FeatureTestCase
     public function it_fails_when_docker_compose_file_not_found(): void
     {
         $this->artisan('laradox:up')
-            ->expectsOutput('Docker Compose file not found: ' . base_path('docker-compose.development.yml'))
+            ->expectsOutput('✗ Docker Compose file not found: docker-compose.development.yml')
             ->assertExitCode(1);
     }
 
@@ -59,7 +59,7 @@ class UpCommandTest extends FeatureTestCase
         File::put($httpsConfigPath, 'https config');
 
         $this->artisan('laradox:up', ['--detach' => true])
-            ->expectsOutput('Starting Laradox (development environment)...')
+            ->expectsOutput('Starting Laradox using docker-compose.development.yml...')
             ->doesntExpectOutput('Docker Compose file not found');
     }
 
@@ -77,7 +77,7 @@ class UpCommandTest extends FeatureTestCase
         File::put($httpsConfigPath, 'https config');
 
         $this->artisan('laradox:up', ['--build' => true])
-            ->expectsOutput('Starting Laradox (development environment)...')
+            ->expectsOutput('Starting Laradox using docker-compose.development.yml...')
             ->doesntExpectOutput('Docker Compose file not found');
     }
 
@@ -93,7 +93,7 @@ class UpCommandTest extends FeatureTestCase
         File::ensureDirectoryExists(dirname($httpsConfigPath));
         File::put($httpsConfigPath, 'https config');
         $this->artisan('laradox:up')
-            ->expectsOutput('Starting Laradox (development environment)...')
+            ->expectsOutput('Starting Laradox using docker-compose.development.yml...')
             ->doesntExpectOutput('Docker Compose file not found');
     }
 

--- a/tests/Unit/DockerCheckTest.php
+++ b/tests/Unit/DockerCheckTest.php
@@ -2,6 +2,7 @@
 
 namespace Laradox\Tests\Unit;
 
+use Illuminate\Support\Facades\File;
 use Laradox\Console\UpCommand;
 use Laradox\Tests\TestCase;
 use Mockery;
@@ -447,5 +448,193 @@ class DockerCheckTest extends TestCase
         foreach ($expectedCommands as $expectedCommand) {
             $this->assertIsString($expectedCommand);
         }
+    }
+
+    #[Test]
+    public function it_gets_docker_compose_command(): void
+    {
+        $command = new class extends UpCommand {
+            public function getDockerComposeCommand(): string
+            {
+                return parent::getDockerComposeCommand();
+            }
+        };
+
+        $result = $command->getDockerComposeCommand();
+        $this->assertIsString($result);
+        $this->assertContains($result, ['docker compose', 'docker-compose']);
+    }
+
+    #[Test]
+    public function it_returns_docker_compose_v2_when_available(): void
+    {
+        $command = new class extends UpCommand {
+            public function getDockerComposeCommand(): string
+            {
+                // Simulate docker compose v2 being available
+                exec('docker compose version', $output, $returnCode);
+                if ($returnCode === 0) {
+                    return 'docker compose';
+                }
+                return 'docker-compose';
+            }
+        };
+
+        $result = $command->getDockerComposeCommand();
+        // Should return one of the valid commands
+        $this->assertContains($result, ['docker compose', 'docker-compose']);
+    }
+
+    #[Test]
+    public function it_falls_back_to_docker_compose_v1(): void
+    {
+        $command = new class extends UpCommand {
+            public function getDockerComposeCommand(): string
+            {
+                // Simulate docker compose v2 NOT being available
+                return 'docker-compose';
+            }
+        };
+
+        $result = $command->getDockerComposeCommand();
+        $this->assertEquals('docker-compose', $result);
+    }
+
+    #[Test]
+    public function it_checks_docker_compose_with_both_v1_and_v2(): void
+    {
+        $command = new class extends UpCommand {
+            public function checkDockerCompose(): bool
+            {
+                return parent::checkDockerCompose();
+            }
+        };
+
+        // This should check both docker compose (v2) and docker-compose (v1)
+        $result = $command->checkDockerCompose();
+        $this->assertIsBool($result);
+    }
+
+    #[Test]
+    public function it_resolves_compose_file_with_custom_file(): void
+    {
+        $command = Mockery::mock(UpCommand::class)->makePartial();
+        $command->shouldAllowMockingProtectedMethods();
+
+        // Test with absolute path
+        $result = $command->resolveComposeFile('development', '/absolute/path/docker-compose.yml');
+        $this->assertEquals('/absolute/path/docker-compose.yml', $result);
+    }
+
+    #[Test]
+    public function it_resolves_compose_file_with_relative_custom_file(): void
+    {
+        $command = Mockery::mock(UpCommand::class)->makePartial();
+        $command->shouldAllowMockingProtectedMethods();
+
+        // Test with relative path
+        $result = $command->resolveComposeFile('development', 'custom-compose.yml');
+        $this->assertEquals(base_path('custom-compose.yml'), $result);
+    }
+
+    #[Test]
+    public function it_resolves_compose_file_with_default_when_exists(): void
+    {
+        // Create a temporary compose file
+        $composeFile = base_path('docker-compose.development.yml');
+        File::put($composeFile, 'version: "3.8"');
+
+        $command = Mockery::mock(UpCommand::class)->makePartial();
+        $command->shouldAllowMockingProtectedMethods();
+
+        $result = $command->resolveComposeFile('development', null);
+        $this->assertEquals($composeFile, $result);
+
+        // Cleanup
+        File::delete($composeFile);
+    }
+
+    #[Test]
+    public function it_returns_false_when_compose_file_not_found_and_no_custom(): void
+    {
+        // Ensure no compose file exists
+        $composeFile = base_path('docker-compose.nonexistent.yml');
+        if (File::exists($composeFile)) {
+            File::delete($composeFile);
+        }
+
+        $command = Mockery::mock(UpCommand::class)->makePartial();
+        $command->shouldAllowMockingProtectedMethods();
+        $command->shouldReceive('newLine')->andReturn(null);
+        $command->shouldReceive('error')->andReturn(null);
+        $command->shouldReceive('line')->andReturn(null);
+        $command->shouldReceive('comment')->andReturn(null);
+
+        $result = $command->resolveComposeFile('nonexistent', null);
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function it_resolves_compose_file_with_empty_custom_file(): void
+    {
+        // Create a temporary compose file
+        $composeFile = base_path('docker-compose.development.yml');
+        File::put($composeFile, 'version: "3.8"');
+
+        $command = Mockery::mock(UpCommand::class)->makePartial();
+        $command->shouldAllowMockingProtectedMethods();
+
+        // Empty string should be treated as no custom file
+        $result = $command->resolveComposeFile('development', '');
+        $this->assertEquals($composeFile, $result);
+
+        // Cleanup
+        File::delete($composeFile);
+    }
+
+    #[Test]
+    public function it_uses_docker_compose_command_in_are_containers_running(): void
+    {
+        $command = new class extends UpCommand {
+            public string $usedCommand = '';
+            
+            protected function getDockerComposeCommand(): string
+            {
+                return 'docker-compose';
+            }
+            
+            public function areContainersRunning(string $composeFile): bool
+            {
+                $dockerCompose = $this->getDockerComposeCommand();
+                $this->usedCommand = $dockerCompose;
+                return false; // Just for testing
+            }
+        };
+
+        $command->areContainersRunning('/some/path/docker-compose.yml');
+        $this->assertEquals('docker-compose', $command->usedCommand);
+    }
+
+    #[Test]
+    public function it_uses_docker_compose_command_in_get_available_services(): void
+    {
+        $command = new class extends UpCommand {
+            public string $usedCommand = '';
+            
+            protected function getDockerComposeCommand(): string
+            {
+                return 'docker-compose';
+            }
+            
+            public function getAvailableServices(string $composeFile): array
+            {
+                $dockerCompose = $this->getDockerComposeCommand();
+                $this->usedCommand = $dockerCompose;
+                return ['nginx', 'php']; // Default for testing
+            }
+        };
+
+        $command->getAvailableServices('/some/path/docker-compose.yml');
+        $this->assertEquals('docker-compose', $command->usedCommand);
     }
 }

--- a/tests/Unit/DownCommandTest.php
+++ b/tests/Unit/DownCommandTest.php
@@ -150,4 +150,48 @@ class DownCommandTest extends TestCase
         $this->assertEquals('development', $developmentEnv);
         $this->assertEquals('production', $productionEnv);
     }
+
+    #[Test]
+    public function it_has_file_option(): void
+    {
+        $command = new DownCommand();
+        
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasOption('file'));
+    }
+
+    #[Test]
+    public function it_file_option_has_shortcut_f(): void
+    {
+        $command = new DownCommand();
+        
+        $definition = $command->getDefinition();
+        $option = $definition->getOption('file');
+        $this->assertEquals('f', $option->getShortcut());
+    }
+
+    #[Test]
+    public function it_constructs_command_with_custom_compose_file(): void
+    {
+        $customFile = 'my-custom-compose.yml';
+        $composeFile = base_path($customFile);
+        $command = sprintf('docker-compose -f %s down', escapeshellarg($composeFile));
+        
+        $this->assertStringContainsString('my-custom-compose.yml', $command);
+        $this->assertStringContainsString('down', $command);
+    }
+
+    #[Test]
+    public function it_supports_both_docker_compose_commands(): void
+    {
+        $composeFile = base_path('docker-compose.development.yml');
+        
+        // Test with docker compose (V2)
+        $commandV2 = sprintf('docker compose -f %s down', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker compose', $commandV2);
+        
+        // Test with docker-compose (V1)
+        $commandV1 = sprintf('docker-compose -f %s down', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker-compose', $commandV1);
+    }
 }

--- a/tests/Unit/LogsCommandTest.php
+++ b/tests/Unit/LogsCommandTest.php
@@ -164,4 +164,48 @@ class LogsCommandTest extends TestCase
         $option = $definition->getOption('follow');
         $this->assertFalse($option->acceptValue());
     }
+
+    #[Test]
+    public function it_has_file_option(): void
+    {
+        $command = new LogsCommand();
+        
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasOption('file'));
+    }
+
+    #[Test]
+    public function it_file_option_accepts_value(): void
+    {
+        $command = new LogsCommand();
+        
+        $definition = $command->getDefinition();
+        $option = $definition->getOption('file');
+        $this->assertTrue($option->acceptValue());
+    }
+
+    #[Test]
+    public function it_constructs_command_with_custom_compose_file(): void
+    {
+        $customFile = 'my-custom-compose.yml';
+        $composeFile = base_path($customFile);
+        $command = sprintf('docker-compose -f %s logs', escapeshellarg($composeFile));
+        
+        $this->assertStringContainsString('my-custom-compose.yml', $command);
+        $this->assertStringContainsString('logs', $command);
+    }
+
+    #[Test]
+    public function it_supports_both_docker_compose_commands(): void
+    {
+        $composeFile = base_path('docker-compose.development.yml');
+        
+        // Test with docker compose (V2)
+        $commandV2 = sprintf('docker compose -f %s logs', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker compose', $commandV2);
+        
+        // Test with docker-compose (V1)
+        $commandV1 = sprintf('docker-compose -f %s logs', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker-compose', $commandV1);
+    }
 }

--- a/tests/Unit/ShellCommandTest.php
+++ b/tests/Unit/ShellCommandTest.php
@@ -182,4 +182,60 @@ class ShellCommandTest extends TestCase
             'ShellCommand should have detectAvailableShell method'
         );
     }
+
+    #[Test]
+    public function it_has_file_option(): void
+    {
+        $command = new ShellCommand();
+        
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasOption('file'));
+    }
+
+    #[Test]
+    public function it_file_option_has_shortcut_f(): void
+    {
+        $command = new ShellCommand();
+        
+        $definition = $command->getDefinition();
+        $option = $definition->getOption('file');
+        $this->assertEquals('f', $option->getShortcut());
+    }
+
+    #[Test]
+    public function it_constructs_command_with_custom_compose_file(): void
+    {
+        $customFile = 'my-custom-compose.yml';
+        $composeFile = base_path($customFile);
+        $command = sprintf('docker-compose -f %s exec', escapeshellarg($composeFile));
+        
+        $this->assertStringContainsString('my-custom-compose.yml', $command);
+        $this->assertStringContainsString('exec', $command);
+    }
+
+    #[Test]
+    public function it_supports_both_docker_compose_commands(): void
+    {
+        $composeFile = base_path('docker-compose.development.yml');
+        
+        // Test with docker compose (V2)
+        $commandV2 = sprintf('docker compose -f %s exec', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker compose', $commandV2);
+        
+        // Test with docker-compose (V1)
+        $commandV1 = sprintf('docker-compose -f %s exec', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker-compose', $commandV1);
+    }
+
+    #[Test]
+    public function it_constructs_ps_command_with_docker_compose(): void
+    {
+        $composeFile = base_path('docker-compose.development.yml');
+        
+        $commandV1 = sprintf('docker-compose -f %s ps --services --filter "status=running"', escapeshellarg($composeFile));
+        $this->assertStringContainsString('ps --services', $commandV1);
+        
+        $commandV2 = sprintf('docker compose -f %s ps --services --filter "status=running"', escapeshellarg($composeFile));
+        $this->assertStringContainsString('ps --services', $commandV2);
+    }
 }

--- a/tests/Unit/UpCommandTest.php
+++ b/tests/Unit/UpCommandTest.php
@@ -205,4 +205,60 @@ class UpCommandTest extends TestCase
         $this->assertEquals('app-https.conf', $httpsConfig);
         $this->assertEquals('app-http.conf', $httpConfig);
     }
+
+    #[Test]
+    public function it_has_file_option(): void
+    {
+        $command = new UpCommand();
+        
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasOption('file'));
+    }
+
+    #[Test]
+    public function it_file_option_has_shortcut_f(): void
+    {
+        $command = new UpCommand();
+        
+        $definition = $command->getDefinition();
+        $option = $definition->getOption('file');
+        $this->assertEquals('f', $option->getShortcut());
+    }
+
+    #[Test]
+    public function it_constructs_command_with_custom_compose_file(): void
+    {
+        $customFile = 'my-custom-compose.yml';
+        $composeFile = base_path($customFile);
+        $command = sprintf('docker-compose -f %s up', escapeshellarg($composeFile));
+        
+        $this->assertStringContainsString('my-custom-compose.yml', $command);
+        $this->assertStringContainsString('up', $command);
+    }
+
+    #[Test]
+    public function it_supports_both_docker_compose_commands(): void
+    {
+        $composeFile = base_path('docker-compose.development.yml');
+        
+        // Test with docker compose (V2)
+        $commandV2 = sprintf('docker compose -f %s up', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker compose', $commandV2);
+        
+        // Test with docker-compose (V1)
+        $commandV1 = sprintf('docker-compose -f %s up', escapeshellarg($composeFile));
+        $this->assertStringContainsString('docker-compose', $commandV1);
+    }
+
+    #[Test]
+    public function it_constructs_restart_command_with_docker_compose(): void
+    {
+        $composeFile = base_path('docker-compose.development.yml');
+        
+        $commandV1 = sprintf('docker-compose -f %s restart', escapeshellarg($composeFile));
+        $this->assertStringContainsString('restart', $commandV1);
+        
+        $commandV2 = sprintf('docker compose -f %s restart', escapeshellarg($composeFile));
+        $this->assertStringContainsString('restart', $commandV2);
+    }
 }


### PR DESCRIPTION
- Added support for custom Docker Compose file paths in commands.
- Improved error messages for missing Docker Compose files.
- Updated commands to use the appropriate Docker Compose command based on version (V1 or V2).
- Modified Docker Compose YAML files to correctly reference environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --file option across CLI commands to specify a custom Docker Compose file.
  * Improved detection and use of Docker Compose (supports V2 with fallback to V1).

* **Bug Fixes**
  * Better error messaging when compose files are missing, with clearer formatting and filename display.
  * Standardized port handling in compose stubs and container startup.

* **Tests**
  * Expanded unit and feature tests covering compose resolution, command construction, and CLI options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->