### PR TITLE
feat: support Laravel 13 and rework the PHP image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,20 +44,25 @@ jobs:
           - php: 8.2
             laravel: 10.*
             testbench: ^8.0
+            eol: true
           - php: 8.3
             laravel: 10.*
             testbench: ^8.0
+            eol: true
 
           # Laravel 11.x - PHP 8.2, 8.3, 8.4
           - php: 8.2
             laravel: 11.*
             testbench: ^9.0
+            eol: true
           - php: 8.3
             laravel: 11.*
             testbench: ^9.0
+            eol: true
           - php: 8.4
             laravel: 11.*
             testbench: ^9.0
+            eol: true
 
           # Laravel 12.x - PHP 8.2, 8.3, 8.4
           - php: 8.2
@@ -96,6 +101,17 @@ jobs:
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      # Laravel 10.x and 11.x are past their security-support windows, so every
+      # release carries advisories that will never be patched and Composer
+      # refuses to resolve them at all. We still want to know the package works
+      # on those versions, so the block is lifted for those rows only — 12.x and
+      # 13.x keep it on, so a new advisory against a supported release will
+      # still fail CI. Note that --no-audit / COMPOSER_NO_AUDIT do not affect
+      # this; only the policy config does (composer/composer#12607).
+      - name: Allow resolving end-of-life framework versions
+        if: ${{ matrix.eol }}
+        run: composer config policy.advisories.block false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,36 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Code Style (Pint)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: highest
+
+      - name: Check code style
+        run: vendor/bin/pint --test
+
   test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +47,7 @@ jobs:
           - php: 8.3
             laravel: 10.*
             testbench: ^8.0
-          
+
           # Laravel 11.x - PHP 8.2, 8.3, 8.4
           - php: 8.2
             laravel: 11.*
@@ -32,7 +58,7 @@ jobs:
           - php: 8.4
             laravel: 11.*
             testbench: ^9.0
-          
+
           # Laravel 12.x - PHP 8.2, 8.3, 8.4
           - php: 8.2
             laravel: 12.*
@@ -43,7 +69,16 @@ jobs:
           - php: 8.4
             laravel: 12.*
             testbench: ^10.0
-            
+
+          # Laravel 13.x - PHP 8.3, 8.4 (Laravel 13 requires PHP >= 8.3)
+          - php: 8.3
+            laravel: 13.*
+            testbench: ^11.0
+          - php: 8.4
+            laravel: 13.*
+            testbench: ^11.0
+            coverage: true
+
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
@@ -55,7 +90,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
-          coverage: pcov
+          coverage: ${{ matrix.coverage && 'pcov' || 'none' }}
 
       - name: Setup problem matchers
         run: |
@@ -65,17 +100,23 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --prefer-dist --no-interaction
+          composer update --prefer-dist --no-interaction --no-progress
 
-      - name: List Installed Dependencies
+      - name: List installed dependencies
         run: composer show -D
 
       - name: Execute tests
+        if: ${{ !matrix.coverage }}
+        run: vendor/bin/phpunit
+
+      - name: Execute tests with coverage
+        if: ${{ matrix.coverage }}
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        if: matrix.php == '8.3' && matrix.laravel == '11.*'
+        if: ${{ matrix.coverage }}
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to `laradox` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Laravel 13.x support (`illuminate/support` and `illuminate/console` now allow `^13.0`)
+  - Orchestra Testbench `^11.0` and PHPUnit `^12.0` accepted in `require-dev`
+  - CI matrix covers Laravel 13.x on PHP 8.3 and 8.4 (Laravel 13 requires PHP >= 8.3)
+- Laravel Pint for code style, with `composer lint` / `composer format` scripts and a CI job
+- `pdo_mysql` extension in the PHP image, alongside the existing `pdo_pgsql`
+- `gd` is now built with JPEG, WebP, and FreeType support
+- Environment-specific OPcache tuning: timestamp validation in development, tracing JIT in production
+- `FRANKENPHP_VERSION`, `PHP_VERSION`, and `SUPERCRONIC_VERSION` build args, so base
+  versions can be overridden without editing the Dockerfile
+
+### Fixed
+- Production containers no longer start Octane with `--watch`. The environment check lived in
+  `CMD`, which is evaluated by the container shell at runtime and could not see the
+  `ENVIRONMENT` build arg, so every container took the development branch. The command is now
+  defined per build stage.
+- Octane now binds to `0.0.0.0` instead of Octane's `127.0.0.1` default, so Nginx can reach the
+  `php` service.
+- `LARADOX_FRANKENPHP_PORT` no longer carries a leading colon, which produced an invalid
+  `--port=:8080`. The Nginx upstream is templated from the same variable, so changing the port
+  now takes effect across the whole stack.
+- The PHP image builds on `arm64` hosts (Apple Silicon). Supercronic was pinned to the
+  `amd64` binary regardless of target architecture.
+- `LARADOX_USER_ID` / `LARADOX_GROUP_ID` are passed through to the image build; previously the
+  `USER_ID`/`GROUP_ID` build args always fell back to `1000`.
+- `COMPOSER_HOME` and `COMPOSER_CACHE_DIR` now match the paths the development compose file
+  mounts, so the host Composer cache and `auth.json` are actually used.
+
+### Changed
+- Base image updated from FrankenPHP 1.7 to 1.12
+- Builder stage consolidated into fewer layers, and build-only packages whose extensions
+  already ship with the base image (`mbstring`, `libxml2`, `oniguruma`, `curl-dev`) removed
+- Supercronic updated from 0.2.29 to 0.2.48
+- Coverage reporting moved out of `phpunit.xml` and onto the CI command, so local test runs no
+  longer require a coverage driver
+
 ## 2.0.7 - 2026-01-24
 
 ### New Features

--- a/PACKAGE_STRUCTURE.md
+++ b/PACKAGE_STRUCTURE.md
@@ -62,6 +62,7 @@ laradox/
 ├── LICENSE
 ├── PACKAGE_STRUCTURE.md
 ├── phpunit.xml
+├── pint.json                                # Laravel Pint code style config
 ├── QUICKSTART.md
 └── README.md
 ```

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,7 +4,7 @@ Get your Laravel application running with Docker in less than 5 minutes!
 
 ## Prerequisites
 
-- PHP 8.2+ and Composer installed locally
+- PHP 8.2+ and Composer installed locally (PHP 8.3+ for Laravel 13.x)
 - Docker and Docker Compose (Laradox will detect and help install if missing)
 - [mkcert](https://github.com/FiloSottile/mkcert) (Laradox will detect and help install if missing)
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Comparison of performance measurements between *without* and *with* FrankenPHP u
 
 ## Requirements
 
-- PHP 8.2 or higher
-- Laravel 10.x, 11.x, or 12.x
+- PHP 8.2 or higher (PHP 8.3+ when using Laravel 13.x)
+- Laravel 10.x, 11.x, 12.x, or 13.x
 - Docker and Docker Compose (auto-detected, installation prompted if missing)
 - [mkcert](https://github.com/FiloSottile/mkcert) (auto-detected, installation prompted if missing)
 
@@ -316,6 +316,34 @@ Laradox includes the following services:
 - **node**: Node.js for asset compilation
 - **scheduler**: Laravel scheduler (development) or Supercronic (production)
 - **queue**: Laravel queue worker with Supervisor (production only)
+
+### PHP Image
+
+The `php` service is built from `docker/php/php.dockerfile` — a multi-stage build where all
+compilation happens in a throwaway `builder` stage, so the runtime image only carries the
+shared libraries it actually needs.
+
+**Bundled extensions:** `bcmath`, `excimer`, `gd` (with JPEG/WebP/FreeType), `intl`, `pcntl`,
+`pdo_mysql`, `pdo_pgsql`, `redis`, `uv`, `zip`, plus everything in the FrankenPHP base image
+(`opcache`, `mbstring`, `dom`, `curl`, `sqlite3`, …).
+
+**OPcache** is tuned per environment: development validates timestamps so `--watch` reloads
+pick up edits, while production disables timestamp validation and enables the tracing JIT.
+Because production caches compiled code indefinitely, deploys need an image rebuild or
+`php artisan octane:reload`.
+
+**Build args** — override in the `build.args` block of your compose file:
+
+| Arg | Default | Purpose |
+|-----|---------|---------|
+| `FRANKENPHP_VERSION` | `1.12` | FrankenPHP base image version |
+| `PHP_VERSION` | `8.4` | PHP version of the base image |
+| `ENVIRONMENT` | `development` | Selects the `development` or `production` stage |
+| `USER_ID` / `GROUP_ID` | `1000` | Host uid/gid, so bind-mounted files stay writable |
+| `SUPERCRONIC_VERSION` | `0.2.48` | Supercronic release to download |
+
+The image is architecture-aware, so it builds on both `amd64` and `arm64` hosts
+(Apple Silicon included).
 
 ### Scheduler Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,13 @@
     },
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/console": "^10.0|^11.0|^12.0"
+        "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0|^11.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0"
+        "laravel/pint": "^1.18",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {
@@ -63,6 +64,8 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "lint": "pint --test",
+        "format": "pint"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,13 +14,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <source>
         <include>
             <directory suffix=".php">src</directory>

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,22 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "declare_strict_types": false,
+        "fully_qualified_strict_types": true,
+        "global_namespace_import": {
+            "import_classes": true,
+            "import_constants": false,
+            "import_functions": false
+        },
+        "ordered_imports": {
+            "sort_algorithm": "alpha"
+        },
+        "no_unused_imports": true,
+        "single_line_comment_style": true
+    },
+    "exclude": [
+        "stubs",
+        "vendor",
+        "build"
+    ]
+}

--- a/src/Console/Concerns/ChecksDocker.php
+++ b/src/Console/Concerns/ChecksDocker.php
@@ -6,20 +6,17 @@ trait ChecksDocker
 {
     /**
      * Check if Docker is installed.
-     *
-     * @return bool
      */
     protected function checkDocker(): bool
     {
         exec('docker --version', $output, $returnCode);
         $output = $output ?? [];
+
         return $returnCode === 0;
     }
 
     /**
      * Check if Docker Compose is installed.
-     *
-     * @return bool
      */
     protected function checkDockerCompose(): bool
     {
@@ -30,6 +27,7 @@ trait ChecksDocker
         }
         // Fallback to 'docker-compose' (Docker Compose V1)
         exec('docker-compose version', $output, $returnCode);
+
         return $returnCode === 0;
     }
 
@@ -37,8 +35,6 @@ trait ChecksDocker
      * Get the available Docker Compose command.
      *
      * Returns 'docker compose' if available (V2), otherwise 'docker-compose' (V1).
-     *
-     * @return string
      */
     protected function getDockerComposeCommand(): string
     {
@@ -46,6 +42,7 @@ trait ChecksDocker
         if ($returnCode === 0) {
             return 'docker compose';
         }
+
         return 'docker-compose';
     }
 
@@ -57,8 +54,8 @@ trait ChecksDocker
      * If the default file doesn't exist and no custom file is provided,
      * prompts the user to specify one using the -f flag.
      *
-     * @param string $environment The environment (development|production)
-     * @param string|null $customFile Custom compose file path from -f option
+     * @param  string  $environment  The environment (development|production)
+     * @param  string|null  $customFile  Custom compose file path from -f option
      * @return string|false The resolved compose file path, or false on failure
      */
     protected function resolveComposeFile(string $environment, ?string $customFile): string|false
@@ -68,12 +65,13 @@ trait ChecksDocker
             if (str_starts_with($customFile, '/')) {
                 return $customFile;
             }
+
             return base_path($customFile);
         }
 
         // Try default compose file for the environment
         $defaultFile = base_path("docker-compose.{$environment}.yml");
-        
+
         if (file_exists($defaultFile)) {
             return $defaultFile;
         }
@@ -89,16 +87,16 @@ trait ChecksDocker
         $this->comment('     php artisan vendor:publish --tag=laradox-docker');
         $this->newLine();
         $this->line('  2. Use a custom compose file with the -f option:');
-        $this->comment("     php artisan laradox:up -f docker-compose.yml");
-        $this->comment("     php artisan laradox:up -f my-custom-compose.yml");
+        $this->comment('     php artisan laradox:up -f docker-compose.yml');
+        $this->comment('     php artisan laradox:up -f my-custom-compose.yml');
         $this->newLine();
-        
+
         // Check if any docker-compose*.yml files exist
         $existingFiles = glob(base_path('docker-compose*.yml'));
-        if (!empty($existingFiles)) {
+        if (! empty($existingFiles)) {
             $this->line('  Available compose files in your project:');
             foreach ($existingFiles as $file) {
-                $this->comment('     ' . basename($file));
+                $this->comment('     '.basename($file));
             }
             $this->newLine();
         }
@@ -108,8 +106,6 @@ trait ChecksDocker
 
     /**
      * Handle missing Docker installation.
-     *
-     * @return int
      */
     protected function handleMissingDocker(): int
     {
@@ -162,8 +158,6 @@ trait ChecksDocker
      *
      * Note: Requires systemd for service management. On WSL, containers,
      * or non-systemd distributions, manual installation may be needed.
-     *
-     * @return int
      */
     protected function installDockerLinux(): int
     {
@@ -181,6 +175,7 @@ trait ChecksDocker
             if ($distro === 'debian') {
                 return $this->installDockerDebian();
             }
+
             return $this->installDockerUbuntu();
         } elseif ($hasDnf) {
             return $this->installDockerFedora();
@@ -189,14 +184,13 @@ trait ChecksDocker
         } else {
             $this->error('Could not detect Linux distribution (apt, yum, or dnf).');
             $this->line('Please install Docker manually: https://docs.docker.com/engine/install/');
+
             return 1; // FAILURE
         }
     }
 
     /**
      * Install Docker on Ubuntu.
-     *
-     * @return int
      */
     protected function installDockerUbuntu(): int
     {
@@ -226,9 +220,10 @@ trait ChecksDocker
         foreach ($commands as $command) {
             $this->line("Running: {$command}");
             passthru($command, $returnCode);
-            if ($returnCode !== 0 && !str_contains($command, 'remove')) {
+            if ($returnCode !== 0 && ! str_contains($command, 'remove')) {
                 $this->error('Installation failed.');
                 $this->line('Please try installing manually: https://docs.docker.com/engine/install/ubuntu/');
+
                 return 1; // FAILURE
             }
         }
@@ -254,8 +249,6 @@ trait ChecksDocker
 
     /**
      * Install Docker on Debian.
-     *
-     * @return int
      */
     protected function installDockerDebian(): int
     {
@@ -285,9 +278,10 @@ trait ChecksDocker
         foreach ($commands as $command) {
             $this->line("Running: {$command}");
             passthru($command, $returnCode);
-            if ($returnCode !== 0 && !str_contains($command, 'remove')) {
+            if ($returnCode !== 0 && ! str_contains($command, 'remove')) {
                 $this->error('Installation failed.');
                 $this->line('Please try installing manually: https://docs.docker.com/engine/install/debian/');
+
                 return 1; // FAILURE
             }
         }
@@ -313,8 +307,6 @@ trait ChecksDocker
 
     /**
      * Install Docker on Fedora.
-     *
-     * @return int
      */
     protected function installDockerFedora(): int
     {
@@ -337,9 +329,10 @@ trait ChecksDocker
         foreach ($commands as $command) {
             $this->line("Running: {$command}");
             passthru($command, $returnCode);
-            if ($returnCode !== 0 && !str_contains($command, 'remove')) {
+            if ($returnCode !== 0 && ! str_contains($command, 'remove')) {
                 $this->error('Installation failed.');
                 $this->line('Please try installing manually: https://docs.docker.com/engine/install/fedora/');
+
                 return 1; // FAILURE
             }
         }
@@ -364,8 +357,6 @@ trait ChecksDocker
 
     /**
      * Install Docker on CentOS/RHEL.
-     *
-     * @return int
      */
     protected function installDockerCentOS(): int
     {
@@ -388,9 +379,10 @@ trait ChecksDocker
         foreach ($commands as $command) {
             $this->line("Running: {$command}");
             passthru($command, $returnCode);
-            if ($returnCode !== 0 && !str_contains($command, 'remove')) {
+            if ($returnCode !== 0 && ! str_contains($command, 'remove')) {
                 $this->error('Installation failed.');
                 $this->line('Please try installing manually: https://docs.docker.com/engine/install/centos/');
+
                 return 1; // FAILURE
             }
         }
@@ -435,7 +427,7 @@ trait ChecksDocker
 
         // Fallback: check for lsb_release command
         exec('lsb_release -is 2>/dev/null', $output, $returnCode);
-        if ($returnCode === 0 && !empty($output)) {
+        if ($returnCode === 0 && ! empty($output)) {
             $distro = strtolower(trim($output[0]));
             if ($distro === 'debian') {
                 return 'debian';
@@ -470,42 +462,34 @@ trait ChecksDocker
 
     /**
      * Check if a command is available.
-     *
-     * @param string $command
-     * @return bool
      */
     protected function commandAvailable(string $command): bool
     {
-        exec('which ' . escapeshellarg($command), $output, $returnCode);
+        exec('which '.escapeshellarg($command), $output, $returnCode);
         unset($output);
+
         return $returnCode === 0;
     }
 
     /**
      * Open a URL in the default browser.
-     *
-     * @param string $url
-     * @return void
      */
     protected function openBrowser(string $url): void
     {
         $os = $this->detectOperatingSystem();
 
         if ($os === 'macos') {
-            exec("open " . escapeshellarg($url));
+            exec('open '.escapeshellarg($url));
         } elseif ($os === 'linux') {
-            exec("xdg-open " . escapeshellarg($url) . " 2>/dev/null &");
+            exec('xdg-open '.escapeshellarg($url).' 2>/dev/null &');
         } elseif ($os === 'windows') {
             // Use an empty window title to ensure the URL is treated as the target
-            exec('start "" ' . escapeshellarg($url));
+            exec('start "" '.escapeshellarg($url));
         }
     }
 
     /**
      * Check if containers are running for the given compose file.
-     *
-     * @param string $composeFile
-     * @return bool
      */
     protected function areContainersRunning(string $composeFile): bool
     {
@@ -518,14 +502,11 @@ trait ChecksDocker
 
         exec($command, $output, $returnCode);
 
-        return $returnCode === 0 && !empty($output);
+        return $returnCode === 0 && ! empty($output);
     }
 
     /**
      * Get list of available services from the compose file.
-     *
-     * @param string $composeFile
-     * @return array
      */
     protected function getAvailableServices(string $composeFile): array
     {

--- a/src/Console/DownCommand.php
+++ b/src/Console/DownCommand.php
@@ -8,6 +8,7 @@ use Laradox\Console\Concerns\ChecksDocker;
 class DownCommand extends Command
 {
     use ChecksDocker;
+
     /**
      * The name and signature of the console command.
      *
@@ -31,31 +32,33 @@ class DownCommand extends Command
     public function handle(): int
     {
         // Check if Docker is installed
-        if (!$this->checkDocker()) {
+        if (! $this->checkDocker()) {
             return $this->handleMissingDocker();
         }
 
         // Check if Docker Compose is available
-        if (!$this->checkDockerCompose()) {
+        if (! $this->checkDockerCompose()) {
             $this->newLine();
             $this->error('✗ Docker Compose is not available.');
             $this->line('Please ensure Docker Compose is installed and running.');
             $this->line('Visit: https://docs.docker.com/compose/install/');
             $this->newLine();
+
             return self::FAILURE;
         }
 
         $env = $this->option('environment');
         $customFile = $this->option('file');
-        
+
         // Determine compose file path
         $composeFile = $this->resolveComposeFile($env, $customFile);
         if ($composeFile === false) {
             return self::FAILURE;
         }
 
-        if (!file_exists($composeFile)) {
+        if (! file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
+
             return self::FAILURE;
         }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -44,7 +44,7 @@ class InstallCommand extends Command
 
         // Create SSL directory if it doesn't exist
         $sslDir = base_path('docker/nginx/ssl');
-        if (!File::exists($sslDir)) {
+        if (! File::exists($sslDir)) {
             File::makeDirectory($sslDir, 0755, true);
             $this->info('Created SSL directory: docker/nginx/ssl');
         }

--- a/src/Console/LogsCommand.php
+++ b/src/Console/LogsCommand.php
@@ -8,6 +8,7 @@ use Laradox\Console\Concerns\ChecksDocker;
 class LogsCommand extends Command
 {
     use ChecksDocker;
+
     /**
      * The name and signature of the console command.
      *
@@ -30,38 +31,38 @@ class LogsCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
     public function handle(): int
     {
         $env = $this->option('environment');
         $customFile = $this->option('file');
-        
+
         // Determine compose file path
         $composeFile = $this->resolveComposeFile($env, $customFile);
         if ($composeFile === false) {
             return self::FAILURE;
         }
 
-        if (!file_exists($composeFile)) {
+        if (! file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
+
             return self::FAILURE;
         }
 
         // Check if containers are running
-        if (!$this->areContainersRunning($composeFile)) {
+        if (! $this->areContainersRunning($composeFile)) {
             $this->newLine();
             $this->error('✗ No containers are running!');
             $this->line('Start containers with: php artisan laradox:up --detach');
             $this->newLine();
+
             return self::FAILURE;
         }
 
         $service = $this->argument('service');
 
         // If no service specified, show all available services
-        if (!$service) {
+        if (! $service) {
             $this->info('Available services:');
             $services = $this->getAvailableServices($composeFile);
             foreach ($services as $serviceName) {
@@ -71,6 +72,7 @@ class LogsCommand extends Command
             $this->comment('Usage: php artisan laradox:logs [service]');
             $this->comment('Example: php artisan laradox:logs php --follow');
             $this->newLine();
+
             return self::SUCCESS;
         }
 
@@ -88,8 +90,9 @@ class LogsCommand extends Command
 
         if ($this->option('tail')) {
             $tail = $this->option('tail');
-            if (!is_numeric($tail) || $tail < 1) {
+            if (! is_numeric($tail) || $tail < 1) {
                 $this->error('The --tail option must be a positive integer.');
+
                 return self::FAILURE;
             }
             $command .= sprintf(' --tail=%s', escapeshellarg($this->option('tail')));
@@ -99,7 +102,7 @@ class LogsCommand extends Command
             $command .= ' --timestamps';
         }
 
-        $command .= ' ' . escapeshellarg($service);
+        $command .= ' '.escapeshellarg($service);
 
         $this->info("Viewing logs for '{$service}' service...");
         $this->line($this->option('follow') ? 'Press Ctrl+C to stop following logs' : '');

--- a/src/Console/SetupSSLCommand.php
+++ b/src/Console/SetupSSLCommand.php
@@ -36,13 +36,13 @@ class SetupSSLCommand extends Command
         $this->info('Setting up SSL certificates...');
 
         // Check if mkcert is installed
-        if (!$this->checkMkcert()) {
+        if (! $this->checkMkcert()) {
             return $this->handleMissingMkcert();
         }
 
         $domain = $this->option('domain') ?: config('laradox.domain');
         $additionalDomains = $this->option('additional-domains') ?: config('laradox.additional_domains', []);
-        
+
         $domains = array_merge([$domain], $additionalDomains);
         $domainsString = implode(' ', array_map('escapeshellarg', $domains));
 
@@ -51,7 +51,7 @@ class SetupSSLCommand extends Command
 
         // Ensure SSL directory exists
         $sslDir = dirname($certPath);
-        if (!File::exists($sslDir)) {
+        if (! File::exists($sslDir)) {
             File::makeDirectory($sslDir, 0755, true);
         }
 
@@ -71,7 +71,8 @@ class SetupSSLCommand extends Command
             $this->info('✓ SSL certificates generated successfully!');
             $this->line("Certificate: {$certPath}");
             $this->line("Key: {$keyPath}");
-            $this->line("Domains: " . implode(', ', $domains));
+            $this->line('Domains: '.implode(', ', $domains));
+
             return self::SUCCESS;
         }
 
@@ -89,13 +90,12 @@ class SetupSSLCommand extends Command
     protected function checkMkcert(): bool
     {
         exec('which mkcert', $output, $returnCode);
+
         return $returnCode === 0;
     }
 
     /**
      * Handle missing mkcert installation.
-     *
-     * @return int
      */
     protected function handleMissingMkcert(): int
     {
@@ -156,8 +156,6 @@ class SetupSSLCommand extends Command
 
     /**
      * Install mkcert on Linux.
-     *
-     * @return int
      */
     protected function installMkcertLinux(): int
     {
@@ -188,6 +186,7 @@ class SetupSSLCommand extends Command
         } else {
             $this->error('Could not detect package manager (apt, yum, or dnf).');
             $this->line('Please install mkcert manually: https://github.com/FiloSottile/mkcert');
+
             return self::FAILURE;
         }
 
@@ -196,6 +195,7 @@ class SetupSSLCommand extends Command
             passthru($command, $returnCode);
             if ($returnCode !== 0) {
                 $this->error('Installation failed.');
+
                 return self::FAILURE;
             }
         }
@@ -211,15 +211,14 @@ class SetupSSLCommand extends Command
 
     /**
      * Install mkcert on macOS using Homebrew.
-     *
-     * @return int
      */
     protected function installMkcertMacOS(): int
     {
-        if (!$this->commandExists('brew')) {
+        if (! $this->commandExists('brew')) {
             $this->error('Homebrew is not installed.');
             $this->line('Please install Homebrew first: https://brew.sh');
             $this->line('Or install mkcert manually: https://github.com/FiloSottile/mkcert');
+
             return self::FAILURE;
         }
 
@@ -232,6 +231,7 @@ class SetupSSLCommand extends Command
 
         if ($returnCode !== 0) {
             $this->error('Installation failed.');
+
             return self::FAILURE;
         }
 
@@ -246,32 +246,27 @@ class SetupSSLCommand extends Command
 
     /**
      * Check if a command exists.
-     *
-     * @param string $command
-     * @return bool
      */
     protected function commandExists(string $command): bool
     {
         exec("which {$command}", $output, $returnCode);
+
         return $returnCode === 0;
     }
 
     /**
      * Open a URL in the default browser.
-     *
-     * @param string $url
-     * @return void
      */
     protected function openURL(string $url): void
     {
         $os = $this->detectOS();
 
         if ($os === 'macos') {
-            exec("open " . escapeshellarg($url));
+            exec('open '.escapeshellarg($url));
         } elseif ($os === 'linux') {
-            exec("xdg-open " . escapeshellarg($url));
+            exec('xdg-open '.escapeshellarg($url));
         } elseif ($os === 'windows') {
-            exec("start " . escapeshellarg($url));
+            exec('start '.escapeshellarg($url));
         }
     }
 }

--- a/src/Console/ShellCommand.php
+++ b/src/Console/ShellCommand.php
@@ -8,6 +8,7 @@ use Laradox\Console\Concerns\ChecksDocker;
 class ShellCommand extends Command
 {
     use ChecksDocker;
+
     /**
      * The name and signature of the console command.
      *
@@ -29,46 +30,47 @@ class ShellCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return int
      */
     public function handle(): int
     {
         // Check if Docker is installed
-        if (!$this->checkDocker()) {
+        if (! $this->checkDocker()) {
             return $this->handleMissingDocker();
         }
 
         // Check if Docker Compose is available
-        if (!$this->checkDockerCompose()) {
+        if (! $this->checkDockerCompose()) {
             $this->newLine();
             $this->error('✗ Docker Compose is not available.');
             $this->line('Please ensure Docker Compose is installed and running.');
             $this->line('Visit: https://docs.docker.com/compose/install/');
             $this->newLine();
+
             return self::FAILURE;
         }
 
         $env = $this->option('environment');
         $customFile = $this->option('file');
-        
+
         // Determine compose file path
         $composeFile = $this->resolveComposeFile($env, $customFile);
         if ($composeFile === false) {
             return self::FAILURE;
         }
 
-        if (!file_exists($composeFile)) {
+        if (! file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
+
             return self::FAILURE;
         }
 
         // Check if containers are running
-        if (!$this->areContainersRunning($composeFile)) {
+        if (! $this->areContainersRunning($composeFile)) {
             $this->newLine();
             $this->error('✗ No containers are running!');
             $this->line('Start containers with: php artisan laradox:up --detach');
             $this->newLine();
+
             return self::FAILURE;
         }
 
@@ -76,7 +78,7 @@ class ShellCommand extends Command
 
         // Validate service exists
         $availableServices = $this->getAvailableServices($composeFile);
-        if (!in_array($service, $availableServices)) {
+        if (! in_array($service, $availableServices)) {
             $this->error("Service '{$service}' not found in {$env} environment.");
             $this->newLine();
             $this->info('Available services:');
@@ -84,13 +86,15 @@ class ShellCommand extends Command
                 $this->line("  - {$serviceName}");
             }
             $this->newLine();
+
             return self::FAILURE;
         }
 
         // Check if service is running
-        if (!$this->isServiceRunning($composeFile, $service)) {
+        if (! $this->isServiceRunning($composeFile, $service)) {
             $this->error("Service '{$service}' is not running.");
             $this->line('Start containers with: php artisan laradox:up --detach');
+
             return self::FAILURE;
         }
 
@@ -98,9 +102,10 @@ class ShellCommand extends Command
         $requestedShell = $this->option('shell');
         $availableShell = $this->detectAvailableShell($composeFile, $service, $requestedShell);
 
-        if (!$availableShell) {
+        if (! $availableShell) {
             $this->error("No shell found in '{$service}' container.");
-            $this->line('Tried: ' . $requestedShell . ', sh');
+            $this->line('Tried: '.$requestedShell.', sh');
+
             return self::FAILURE;
         }
 
@@ -119,8 +124,8 @@ class ShellCommand extends Command
 
         $command .= sprintf(' %s %s', escapeshellarg($service), escapeshellarg($availableShell));
 
-        $shellInfo = $availableShell !== $requestedShell 
-            ? "{$availableShell} (fallback from {$requestedShell})" 
+        $shellInfo = $availableShell !== $requestedShell
+            ? "{$availableShell} (fallback from {$requestedShell})"
             : $availableShell;
 
         $this->info("Entering '{$service}' container with {$shellInfo}...");
@@ -134,10 +139,6 @@ class ShellCommand extends Command
 
     /**
      * Check if a specific service is running.
-     *
-     * @param string $composeFile
-     * @param string $service
-     * @return bool
      */
     protected function isServiceRunning(string $composeFile, string $service): bool
     {
@@ -156,20 +157,17 @@ class ShellCommand extends Command
     /**
      * Detect which shell is available in the container.
      *
-     * @param string $composeFile
-     * @param string $service
-     * @param string $preferredShell
      * @return string|null The available shell path or null if none found
      */
     protected function detectAvailableShell(string $composeFile, string $service, string $preferredShell): ?string
     {
         $shellsToTry = [$preferredShell];
-        
+
         // Add common fallbacks if not already in the list
         if ($preferredShell !== 'sh') {
             $shellsToTry[] = 'sh';
         }
-        if ($preferredShell !== 'bash' && !in_array('bash', $shellsToTry)) {
+        if ($preferredShell !== 'bash' && ! in_array('bash', $shellsToTry)) {
             $shellsToTry[] = 'bash';
         }
 

--- a/src/Console/UpCommand.php
+++ b/src/Console/UpCommand.php
@@ -8,6 +8,7 @@ use Laradox\Console\Concerns\ChecksDocker;
 class UpCommand extends Command
 {
     use ChecksDocker;
+
     /**
      * The name and signature of the console command.
      *
@@ -40,31 +41,33 @@ class UpCommand extends Command
     public function handle(): int
     {
         // Check if Docker is installed
-        if (!$this->checkDocker()) {
+        if (! $this->checkDocker()) {
             return $this->handleMissingDocker();
         }
 
         // Check if Docker Compose is available
-        if (!$this->checkDockerCompose()) {
+        if (! $this->checkDockerCompose()) {
             $this->newLine();
             $this->error('✗ Docker Compose is not available.');
             $this->line('Please ensure Docker Compose is installed and running.');
             $this->line('Visit: https://docs.docker.com/compose/install/');
             $this->newLine();
+
             return self::FAILURE;
         }
 
         $env = $this->option('environment');
         $customFile = $this->option('file');
-        
+
         // Determine compose file path
         $composeFile = $this->resolveComposeFile($env, $customFile);
         if ($composeFile === false) {
             return self::FAILURE;
         }
 
-        if (!file_exists($composeFile)) {
+        if (! file_exists($composeFile)) {
             $this->error("Docker Compose file not found: {$composeFile}");
+
             return self::FAILURE;
         }
 
@@ -83,12 +86,12 @@ class UpCommand extends Command
         }
 
         // Copy the appropriate nginx config
-        if (!$this->copyNginxConfig($nginxConfigSource)) {
+        if (! $this->copyNginxConfig($nginxConfigSource)) {
             return self::FAILURE;
         }
 
         // Check if domain is added to hosts file (for non-.localhost domains)
-        if (!$this->checkHostsFileConfirmation()) {
+        if (! $this->checkHostsFileConfirmation()) {
             return self::FAILURE;
         }
 
@@ -98,17 +101,18 @@ class UpCommand extends Command
             $this->warn('⚠ Containers are already running!');
             $this->line('Use "php artisan laradox:down" to stop them first, or restart with "docker compose restart"');
             $this->newLine();
-            
-            if (!$this->confirm('Do you want to restart the containers?', false)) {
+
+            if (! $this->confirm('Do you want to restart the containers?', false)) {
                 $this->info('Cancelled.');
+
                 return self::SUCCESS;
             }
-            
+
             $this->info('Restarting containers...');
             $dockerCompose = $this->getDockerComposeCommand();
             $restartCommand = sprintf('%s -f %s restart', $dockerCompose, escapeshellarg($composeFile));
             passthru($restartCommand, $returnCode);
-            
+
             if ($returnCode === 0) {
                 $this->newLine();
                 $this->info('✓ Containers restarted successfully!');
@@ -116,7 +120,7 @@ class UpCommand extends Command
                 $protocol = $sslExists && $forceSsl !== 'false' ? 'https' : 'http';
                 $this->line("Visit: {$protocol}://{$domain}");
             }
-            
+
             return $returnCode === 0 ? self::SUCCESS : self::FAILURE;
         }
 
@@ -157,9 +161,9 @@ class UpCommand extends Command
     /**
      * Choose the nginx configuration file to use based on environment, SSL availability, and the force-ssl option.
      *
-     * @param string $env The environment name, typically 'development' or 'production'.
-     * @param bool $sslExists True if both SSL certificate and key files exist at configured paths.
-     * @param string|null $forceSsl If provided, coerced to boolean: `"true"` requires HTTPS, `"false"` forces HTTP; `null` means auto-detect.
+     * @param  string  $env  The environment name, typically 'development' or 'production'.
+     * @param  bool  $sslExists  True if both SSL certificate and key files exist at configured paths.
+     * @param  string|null  $forceSsl  If provided, coerced to boolean: `"true"` requires HTTPS, `"false"` forces HTTP; `null` means auto-detect.
      * @return string|false The chosen nginx config filename (`'app-https.conf'` or `'app-http.conf'`), or `false` when the operation is cancelled or required SSL prerequisites are missing.
      */
     protected function determineNginxConfig(string $env, bool $sslExists, ?string $forceSsl): string|false
@@ -170,10 +174,10 @@ class UpCommand extends Command
         // Handle --force-ssl flag
         if ($forceSsl !== null) {
             $forceSslBool = filter_var($forceSsl, FILTER_VALIDATE_BOOLEAN);
-            
+
             if ($forceSslBool) {
                 // Force SSL: require certificates
-                if (!$sslExists) {
+                if (! $sslExists) {
                     $this->newLine();
                     $this->error('✗ SSL is forced but certificates not found!');
                     $this->line('Certificates must exist at:');
@@ -182,19 +186,22 @@ class UpCommand extends Command
                     $this->newLine();
                     $this->comment('Generate certificates with: php artisan laradox:setup-ssl');
                     $this->newLine();
+
                     return false;
                 }
                 $this->info('✓ Force SSL enabled, using HTTPS configuration');
+
                 return 'app-https.conf';
             } else {
                 // Force HTTP only
                 $this->warn('⚠ Force HTTP enabled, SSL disabled');
+
                 return 'app-http.conf';
             }
         }
 
         // Production MUST have SSL (unless explicitly forced to HTTP)
-        if ($env === 'production' && !$sslExists) {
+        if ($env === 'production' && ! $sslExists) {
             $this->newLine();
             $this->error('✗ SSL certificates are required for production environment!');
             $this->line('Certificates must exist at:');
@@ -204,11 +211,12 @@ class UpCommand extends Command
             $this->comment('Generate certificates with: php artisan laradox:setup-ssl');
             $this->comment('Or use --force-ssl=false to skip SSL (not recommended for production)');
             $this->newLine();
+
             return false;
         }
 
         // Development: ask user preference if no SSL
-        if ($env === 'development' && !$sslExists) {
+        if ($env === 'development' && ! $sslExists) {
             $this->newLine();
             $this->warn('⚠ SSL certificates not found!');
             $this->line('Certificates expected at:');
@@ -220,18 +228,21 @@ class UpCommand extends Command
             $this->line('2. Continue with HTTP only (port 80)');
             $this->newLine();
 
-            if (!$this->confirm('Do you want to continue with HTTP only?', false)) {
+            if (! $this->confirm('Do you want to continue with HTTP only?', false)) {
                 $this->info('Cancelled. Please setup SSL certificates first.');
+
                 return false;
             }
 
             $this->warn('Using HTTP-only configuration...');
+
             return 'app-http.conf';
         }
 
         // Use HTTPS config when SSL exists
         if ($sslExists) {
             $this->info('✓ SSL certificates found, using HTTPS configuration');
+
             return 'app-https.conf';
         }
 
@@ -244,7 +255,7 @@ class UpCommand extends Command
      * If the named source file does not exist or the copy operation fails,
      * the method returns false.
      *
-     * @param string $configFile Filename of the nginx configuration to copy (e.g. `app-https.conf`).
+     * @param  string  $configFile  Filename of the nginx configuration to copy (e.g. `app-https.conf`).
      * @return bool True on successful copy, false on failure.
      */
     protected function copyNginxConfig(string $configFile): bool
@@ -252,27 +263,30 @@ class UpCommand extends Command
         $sourcePath = base_path("docker/nginx/conf.d/{$configFile}");
         $targetPath = base_path('docker/nginx/conf.d/app.conf');
 
-        if (!file_exists($sourcePath)) {
+        if (! file_exists($sourcePath)) {
             $this->newLine();
             $this->error('✗ Failed to configure nginx!');
             $this->line("Configuration file not found: {$sourcePath}");
             $this->newLine();
+
             return false;
         }
 
         $copyResult = copy($sourcePath, $targetPath);
-        
-        if (!$copyResult) {
+
+        if (! $copyResult) {
             $this->newLine();
             $this->error('✗ Failed to configure nginx!');
             $this->line('Could not copy nginx configuration file.');
             $this->line("Source: {$sourcePath}");
             $this->line("Target: {$targetPath}");
             $this->newLine();
+
             return false;
         }
 
         $this->line("Using nginx configuration: {$configFile}");
+
         return true;
     }
 
@@ -287,7 +301,7 @@ class UpCommand extends Command
     protected function checkHostsFileConfirmation(): bool
     {
         $domain = config('laradox.domain');
-        
+
         // Skip check for .localhost domains (they work without hosts file)
         if (str_ends_with($domain, '.localhost')) {
             return true;
@@ -299,7 +313,7 @@ class UpCommand extends Command
         }
 
         // If running non-interactively without --skip-hosts-check, fail with clear error
-        if (!$this->input->isInteractive()) {
+        if (! $this->input->isInteractive()) {
             $this->newLine();
             $this->error('✗ Custom domain requires hosts file confirmation!');
             $this->line("Domain: {$domain}");
@@ -312,6 +326,7 @@ class UpCommand extends Command
             $this->comment('To configure hosts file, add this line:');
             $this->line("  127.0.0.1 {$domain}");
             $this->newLine();
+
             return false;
         }
 
@@ -326,8 +341,9 @@ class UpCommand extends Command
         $this->comment('On Windows: Edit C:\Windows\System32\drivers\etc\hosts as Administrator');
         $this->newLine();
 
-        if (!$this->confirm('Have you added the domain to your hosts file?', false)) {
+        if (! $this->confirm('Have you added the domain to your hosts file?', false)) {
             $this->info('Cancelled. Please add the domain to your hosts file first.');
+
             return false;
         }
 

--- a/src/LaradoxServiceProvider.php
+++ b/src/LaradoxServiceProvider.php
@@ -3,12 +3,12 @@
 namespace Laradox;
 
 use Illuminate\Support\ServiceProvider;
-use Laradox\Console\InstallCommand;
-use Laradox\Console\SetupSSLCommand;
-use Laradox\Console\UpCommand;
 use Laradox\Console\DownCommand;
+use Laradox\Console\InstallCommand;
 use Laradox\Console\LogsCommand;
+use Laradox\Console\SetupSSLCommand;
 use Laradox\Console\ShellCommand;
+use Laradox\Console\UpCommand;
 
 class LaradoxServiceProvider extends ServiceProvider
 {

--- a/stubs/docker-compose.development.yml
+++ b/stubs/docker-compose.development.yml
@@ -4,6 +4,8 @@ x-php: &php
     dockerfile: php.dockerfile
     args:
       ENVIRONMENT: development
+      USER_ID: ${LARADOX_USER_ID:-1000}
+      GROUP_ID: ${LARADOX_GROUP_ID:-1000}
   restart: unless-stopped
   working_dir: /srv
   volumes:
@@ -21,6 +23,7 @@ services:
       - "${LARADOX_HTTPS_PORT:-443}:443"
     environment:
       - LARADOX_DOMAIN=${LARADOX_DOMAIN:-laravel.docker.localhost}
+      - LARADOX_FRANKENPHP_PORT=${LARADOX_FRANKENPHP_PORT:-8080}
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/nginx/conf.d/app.conf:/etc/nginx/templates/app.conf.template
@@ -52,7 +55,7 @@ services:
   php:
     <<: *php
     environment:
-      - LARADOX_FRANKENPHP_PORT=:${LARADOX_FRANKENPHP_PORT:-8080}
+      - LARADOX_FRANKENPHP_PORT=${LARADOX_FRANKENPHP_PORT:-8080}
     healthcheck:
       test: ["CMD", "php", "-v"]
       interval: 30s

--- a/stubs/docker-compose.production.yml
+++ b/stubs/docker-compose.production.yml
@@ -4,6 +4,8 @@ x-php: &php
     dockerfile: php.dockerfile
     args:
       ENVIRONMENT: production
+      USER_ID: ${LARADOX_USER_ID:-1000}
+      GROUP_ID: ${LARADOX_GROUP_ID:-1000}
   restart: unless-stopped
   working_dir: /srv
   volumes:
@@ -26,6 +28,7 @@ services:
       - "${LARADOX_HTTPS_PORT:-443}:443"
     environment:
       - LARADOX_DOMAIN=${LARADOX_DOMAIN:-laravel.docker.localhost}
+      - LARADOX_FRANKENPHP_PORT=${LARADOX_FRANKENPHP_PORT:-8080}
     volumes:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/nginx/conf.d/app.conf:/etc/nginx/templates/app.conf.template
@@ -42,7 +45,7 @@ services:
   php:
     <<: [*php, *logging]
     environment:
-      - LARADOX_FRANKENPHP_PORT=:${LARADOX_FRANKENPHP_PORT:-8080}
+      - LARADOX_FRANKENPHP_PORT=${LARADOX_FRANKENPHP_PORT:-8080}
     healthcheck:
       test: ["CMD", "php", "-v"]
       interval: 30s

--- a/stubs/docker/nginx/conf.d/app-http.conf
+++ b/stubs/docker/nginx/conf.d/app-http.conf
@@ -1,5 +1,5 @@
 upstream frankenphp_backend {
-    server php:8080;
+    server php:${LARADOX_FRANKENPHP_PORT};
     keepalive 32;
 }
 

--- a/stubs/docker/nginx/conf.d/app-https.conf
+++ b/stubs/docker/nginx/conf.d/app-https.conf
@@ -1,5 +1,5 @@
 upstream frankenphp_backend {
-    server php:8080;
+    server php:${LARADOX_FRANKENPHP_PORT};
     keepalive 32;
 }
 

--- a/stubs/docker/php/php.dockerfile
+++ b/stubs/docker/php/php.dockerfile
@@ -1,107 +1,160 @@
+# syntax=docker/dockerfile:1
+
+# Laradox PHP image (FrankenPHP + Laravel Octane).
+#
+# Build args:
+#   FRANKENPHP_VERSION / PHP_VERSION - base image coordinates
+#   ENVIRONMENT                      - development | production (selects the final stage)
+#   USER_ID / GROUP_ID               - host uid/gid, so bind-mounted files stay writable
+#
+# The runtime port is read from the LARADOX_FRANKENPHP_PORT *environment* variable
+# (not a build arg), so a single image can be started on any port.
+
+ARG FRANKENPHP_VERSION=1.12
+ARG PHP_VERSION=8.4
 ARG ENVIRONMENT=development
-ARG LARADOX_FRANKENPHP_PORT=8080
 
-# STAGE 1: Builder
-FROM dunglas/frankenphp:1.7-php8.4-alpine AS builder
 
+# STAGE 1: Builder — compiles the extensions, then gets thrown away.
+FROM dunglas/frankenphp:${FRANKENPHP_VERSION}-php${PHP_VERSION}-alpine AS builder
+
+ARG TARGETARCH
+ARG SUPERCRONIC_VERSION=0.2.48
+
+# Build-time headers only. mbstring, dom/xml, sqlite, curl and opcache already
+# ship with the base image, so their dev packages are deliberately not here.
 RUN apk add --no-cache \
     $PHPIZE_DEPS \
-    curl-dev \
-    git \
+    curl \
+    freetype-dev \
     icu-dev \
-    libxml2-dev \
-    libzip-dev \
+    jpeg-dev \
     libpng-dev \
-    oniguruma-dev \
-    linux-headers \
-    postgresql-dev \
     libuv-dev \
-    supervisor \
-    && mkdir -p /etc/supervisord.d/
+    libwebp-dev \
+    libzip-dev \
+    linux-headers \
+    postgresql-dev
 
-# Redis via PECL
-RUN pecl install redis \
-    && docker-php-ext-enable redis
+# Bundled + PECL extensions in one layer to keep the image thin.
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && docker-php-ext-install -j"$(nproc)" \
+        bcmath \
+        gd \
+        intl \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+    && pecl channel-update pecl.php.net \
+    && pecl install redis excimer channel://pecl.php.net/uv-0.3.0 \
+    && docker-php-ext-enable redis excimer uv \
+    && rm -rf /tmp/pear /usr/local/lib/php/extensions/*/*.a
 
-# Excimer via PECL
-RUN pecl channel-update pecl.php.net \
-    && pecl install excimer \
-    && docker-php-ext-enable excimer
-
-# Install ext-uv (event loop)
-RUN pecl install channel://pecl.php.net/uv-0.3.0 \
-    && docker-php-ext-enable uv
-
-# PHP extensions default
-RUN docker-php-ext-install -j$(nproc) \
-    bcmath \
-    gd \
-    intl \
-    pcntl \
-    pdo_pgsql \
-    mbstring \
-    zip
-
-# Composer & Supercronic
+# Composer + Supercronic (arch-aware, so arm64 hosts build too).
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
-RUN curl -fsSLo /usr/local/bin/supercronic https://github.com/aptible/supercronic/releases/download/v0.2.29/supercronic-linux-amd64 \
+RUN curl -fsSLo /usr/local/bin/supercronic \
+        "https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-linux-${TARGETARCH}" \
     && chmod +x /usr/local/bin/supercronic
 
 
-# STAGE 2: Base
-FROM dunglas/frankenphp:1.7-php8.4-alpine AS base
+# STAGE 2: Base — shared runtime for both environments.
+FROM dunglas/frankenphp:${FRANKENPHP_VERSION}-php${PHP_VERSION}-alpine AS base
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
-COPY --from=builder /usr/local/bin/composer /usr/local/bin/composer
-COPY --from=builder /usr/local/bin/supercronic /usr/local/bin/supercronic
-
-# copy extensions & conf
-COPY --from=builder /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
-COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
-
-# RUNTIME libs
+# Shared libraries the extensions above link against, plus supervisor for the
+# production queue container.
 RUN apk add --no-cache \
+    freetype \
     icu-libs \
-    libxml2 \
-    libzip \
+    jpeg \
     libpng \
-    oniguruma \
     libpq \
     libuv \
+    libwebp \
+    libzip \
     supervisor
+
+COPY --from=builder /usr/local/bin/composer /usr/local/bin/composer
+COPY --from=builder /usr/local/bin/supercronic /usr/local/bin/supercronic
+COPY --from=builder /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
 
 COPY supervisord.conf /etc/supervisord.conf
 COPY laravel-worker.conf /etc/supervisord.d/laravel-worker.conf
 
-RUN addgroup -g ${GROUP_ID} -S appgroup && \
-    adduser -u ${USER_ID} -S appuser -G appgroup
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_HOME=/config/composer \
+    COMPOSER_CACHE_DIR=/home/composer/.cache/composer \
+    LARADOX_FRANKENPHP_PORT=8080
 
-RUN mkdir -p /data/caddy && chown -R appuser:appgroup /data
+# /data/caddy and /config/caddy are FrankenPHP's state dirs; the composer paths
+# match the cache/auth.json volumes in docker-compose.development.yml.
+RUN addgroup -g ${GROUP_ID} -S appgroup \
+    && adduser -u ${USER_ID} -S appuser -G appgroup \
+    && mkdir -p /data/caddy /config/caddy "${COMPOSER_HOME}" "${COMPOSER_CACHE_DIR}" \
+    && chown -R appuser:appgroup /data /config /home/composer
+
+WORKDIR /srv
+EXPOSE ${LARADOX_FRANKENPHP_PORT}
 
 
 # STAGE 3: Development
 FROM base AS development
-ARG USER_ID
-ARG GROUP_ID
-RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
-RUN mkdir -p /opt/phpstorm-coverage && \
-    chown -R ${USER_ID}:${GROUP_ID} /opt/phpstorm-coverage
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+# JIT stays off and timestamps are validated so --watch reloads pick up edits.
+RUN cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini" \
+    && printf '%s\n' \
+        'memory_limit=512M' \
+        'upload_max_filesize=25M' \
+        'post_max_size=25M' \
+        'opcache.enable=1' \
+        'opcache.enable_cli=1' \
+        'opcache.validate_timestamps=1' \
+        'opcache.revalidate_freq=0' \
+        > "$PHP_INI_DIR/conf.d/zz-laradox.ini" \
+    && mkdir -p /opt/phpstorm-coverage \
+    && chown -R ${USER_ID}:${GROUP_ID} /opt/phpstorm-coverage
+
+USER appuser
+
+# `exec` so PHP becomes PID 1 and receives SIGTERM directly, which lets Octane
+# drain in-flight requests instead of being killed with the shell.
+CMD ["sh", "-c", "exec php artisan octane:frankenphp --watch --host=0.0.0.0 --port=\"${LARADOX_FRANKENPHP_PORT:-8080}\""]
 
 
 # STAGE 4: Production
 FROM base AS production
-RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 
+# Timestamp validation off + tracing JIT: the usual Octane production profile.
+# Requires a deploy-time image rebuild (or `octane:reload`) to pick up new code.
+# enable_cli is on for the long-running CLI workers (queue:work, supercronic).
+RUN cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
+    && printf '%s\n' \
+        'memory_limit=512M' \
+        'upload_max_filesize=25M' \
+        'post_max_size=25M' \
+        'opcache.enable=1' \
+        'opcache.enable_cli=1' \
+        'opcache.memory_consumption=256' \
+        'opcache.interned_strings_buffer=32' \
+        'opcache.max_accelerated_files=20000' \
+        'opcache.validate_timestamps=0' \
+        'opcache.jit=tracing' \
+        'opcache.jit_buffer_size=128M' \
+        > "$PHP_INI_DIR/conf.d/zz-laradox.ini"
 
-# FINAL
-FROM ${ENVIRONMENT}
-ARG ENVIRONMENT
-CMD if [ "$ENVIRONMENT" = "production" ]; then \
-        php artisan octane:frankenphp --port=${LARADOX_FRANKENPHP_PORT}; \
-    else \
-        php artisan octane:frankenphp --watch --port=${LARADOX_FRANKENPHP_PORT}; \
-    fi
-WORKDIR /srv
 USER appuser
+
+# See the development stage for why this is wrapped in `sh -c exec`.
+CMD ["sh", "-c", "exec php artisan octane:frankenphp --host=0.0.0.0 --port=\"${LARADOX_FRANKENPHP_PORT:-8080}\""]
+
+
+# FINAL: alias for the stage named by ENVIRONMENT, so `docker compose build`
+# without an explicit --target still produces the right image.
+FROM ${ENVIRONMENT}

--- a/tests/Feature/DownCommandTest.php
+++ b/tests/Feature/DownCommandTest.php
@@ -90,9 +90,9 @@ class DownCommandTest extends FeatureTestCase
     {
         // This test verifies that the command checks for Docker
         $this->createTestDockerComposeFile();
-        
+
         $result = $this->artisan('laradox:down');
-        
+
         // Command should either succeed with Docker or fail gracefully
         $this->assertContains($result->run(), [0, 1]);
     }
@@ -102,9 +102,9 @@ class DownCommandTest extends FeatureTestCase
     {
         // This test verifies that the command checks for Docker Compose
         $this->createTestDockerComposeFile();
-        
+
         $result = $this->artisan('laradox:down');
-        
+
         // Command should check for Docker Compose availability
         $this->assertContains($result->run(), [0, 1]);
     }

--- a/tests/Feature/SetupSSLCommandTest.php
+++ b/tests/Feature/SetupSSLCommandTest.php
@@ -14,6 +14,7 @@ class SetupSSLCommandTest extends FeatureTestCase
     protected function mkcertInstalled(): bool
     {
         exec('which mkcert 2>/dev/null', $output, $returnCode);
+
         return $returnCode === 0;
     }
 
@@ -23,13 +24,13 @@ class SetupSSLCommandTest extends FeatureTestCase
     protected function setupSslCommand(array $parameters = []): mixed
     {
         $command = $this->artisan('laradox:setup-ssl', $parameters);
-        
+
         // If mkcert is not installed, we need to mock the confirmation prompts
-        if (!$this->mkcertInstalled()) {
+        if (! $this->mkcertInstalled()) {
             // The prompt text depends on the OS, so we mock "no" for Linux (CI default)
             $command->expectsConfirmation('Would you like to install mkcert automatically?', 'no');
         }
-        
+
         return $command;
     }
 
@@ -39,20 +40,20 @@ class SetupSSLCommandTest extends FeatureTestCase
         $this->setupSslCommand()
             ->expectsOutput('Setting up SSL certificates...')
             ->run();
-            
+
         // Test passes if command doesn't crash
         $this->assertTrue(true);
     }
 
     #[Test]
     public function it_checks_for_mkcert_installation(): void
-    {        
+    {
         // In CI/test environments where mkcert isn't installed, command returns 1
         // If mkcert is installed, it succeeds and returns 0
         $result = $this->setupSslCommand()
             ->expectsOutput('Setting up SSL certificates...')
             ->run();
-        
+
         // Accept either exit code since mkcert may or may not be installed
         $this->assertContains($result, [0, 1]);
     }
@@ -75,7 +76,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         $this->setupSslCommand(['--domain' => 'override.docker.localhost'])
             ->expectsOutput('Setting up SSL certificates...')
             ->run();
-            
+
         $this->assertTrue(true);
     }
 
@@ -83,11 +84,11 @@ class SetupSSLCommandTest extends FeatureTestCase
     public function it_accepts_additional_domains_option(): void
     {
         $this->setupSslCommand([
-            '--additional-domains' => ['domain1.test', 'domain2.test']
+            '--additional-domains' => ['domain1.test', 'domain2.test'],
         ])
             ->expectsOutput('Setting up SSL certificates...')
             ->run();
-            
+
         $this->assertTrue(true);
     }
 
@@ -106,7 +107,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // The command will try to create the directory
         // (may fail if mkcert isn't installed, but directory should be created)
         $this->assertTrue(
-            File::exists($sslDir) || !File::exists(dirname($sslDir)),
+            File::exists($sslDir) || ! File::exists(dirname($sslDir)),
             'SSL directory should be created or parent directory should not exist'
         );
     }
@@ -160,7 +161,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         $exitCode = $this->setupSslCommand()
             ->expectsOutput('Setting up SSL certificates...')
             ->run();
-        
+
         // Accept either exit code
         $this->assertContains($exitCode, [0, 1]);
     }
@@ -172,7 +173,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // If mkcert is installed, command succeeds (0)
         // If not installed and user declines/auto-install fails, returns failure (1)
         $exitCode = $this->setupSslCommand()->run();
-        
+
         $this->assertContains($exitCode, [0, 1]);
     }
 
@@ -183,7 +184,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // When mkcert is present, command generates certificates
         // Command should handle both scenarios gracefully
         $exitCode = $this->setupSslCommand()->run();
-        
+
         $this->assertContains($exitCode, [0, 1]);
     }
 
@@ -193,7 +194,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // Test that special characters in domains are handled safely
         $exitCode = $this->setupSslCommand([
             '--domain' => 'test.local',
-            '--additional-domains' => ['*.test.local']
+            '--additional-domains' => ['*.test.local'],
         ])->run();
 
         // Should succeed (exit code 0) or fail (exit code 1) depending on environment
@@ -207,7 +208,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // This is implicitly tested when running the command
         // OS detection should not cause the command to crash
         $exitCode = $this->setupSslCommand()->run();
-        
+
         $this->assertContains($exitCode, [0, 1]);
     }
 
@@ -218,7 +219,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // On other OS, it works normally
         // This test ensures the command doesn't crash regardless of OS
         $exitCode = $this->setupSslCommand()->run();
-        
+
         $this->assertContains($exitCode, [0, 1]);
     }
 
@@ -229,7 +230,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // This test ensures the Linux flow doesn't crash
         // Accepts both success (mkcert installed) and failure (not installed, declined)
         $exitCode = $this->setupSslCommand()->run();
-        
+
         $this->assertContains($exitCode, [0, 1]);
     }
 
@@ -240,7 +241,7 @@ class SetupSSLCommandTest extends FeatureTestCase
         // This test ensures the macOS flow doesn't crash
         // Accepts both success (mkcert installed) and failure (not installed, declined)
         $exitCode = $this->setupSslCommand()->run();
-        
+
         $this->assertContains($exitCode, [0, 1]);
     }
 }

--- a/tests/Feature/UpCommandTest.php
+++ b/tests/Feature/UpCommandTest.php
@@ -52,7 +52,7 @@ class UpCommandTest extends FeatureTestCase
         $this->createTestSslDirectory();
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
         File::put(config('laradox.ssl.key_path'), 'dummy key');
-        
+
         // Create nginx configs
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
         File::ensureDirectoryExists(dirname($httpsConfigPath));
@@ -70,7 +70,7 @@ class UpCommandTest extends FeatureTestCase
         $this->createTestSslDirectory();
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
         File::put(config('laradox.ssl.key_path'), 'dummy key');
-        
+
         // Create nginx configs
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
         File::ensureDirectoryExists(dirname($httpsConfigPath));
@@ -87,7 +87,7 @@ class UpCommandTest extends FeatureTestCase
         $this->createTestDockerComposeFile();
         $this->createTestSslDirectory();
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
-        File::put(config('laradox.ssl.key_path'), 'dummy key');        
+        File::put(config('laradox.ssl.key_path'), 'dummy key');
         // Create nginx configs
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
         File::ensureDirectoryExists(dirname($httpsConfigPath));
@@ -131,15 +131,15 @@ class UpCommandTest extends FeatureTestCase
     {
         $this->createTestDockerComposeFile('development');
         $this->createTestSslDirectory();
-        
+
         // Create both nginx configs
         $httpConfigPath = base_path('docker/nginx/conf.d/app-http.conf');
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
-        
+
         File::ensureDirectoryExists(dirname($httpConfigPath));
         File::put($httpConfigPath, 'http config');
         File::put($httpsConfigPath, 'https config');
-        
+
         // Create valid SSL certificates
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
         File::put(config('laradox.ssl.key_path'), 'dummy key');
@@ -154,15 +154,15 @@ class UpCommandTest extends FeatureTestCase
     {
         $this->createTestDockerComposeFile('development');
         $this->createTestSslDirectory();
-        
+
         // Create both nginx configs
         $httpConfigPath = base_path('docker/nginx/conf.d/app-http.conf');
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
-        
+
         File::ensureDirectoryExists(dirname($httpConfigPath));
         File::put($httpConfigPath, 'http config');
         File::put($httpsConfigPath, 'https config');
-        
+
         // Create valid SSL certificates
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
         File::put(config('laradox.ssl.key_path'), 'dummy key');
@@ -177,11 +177,11 @@ class UpCommandTest extends FeatureTestCase
     {
         $this->createTestDockerComposeFile('development');
         $this->createTestSslDirectory();
-        
+
         // Create nginx configs but NO certificates
         $httpConfigPath = base_path('docker/nginx/conf.d/app-http.conf');
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
-        
+
         File::ensureDirectoryExists(dirname($httpConfigPath));
         File::put($httpConfigPath, 'http config');
         File::put($httpsConfigPath, 'https config');
@@ -196,15 +196,15 @@ class UpCommandTest extends FeatureTestCase
     {
         $this->createTestDockerComposeFile('development');
         $this->createTestSslDirectory();
-        
+
         // Create both nginx configs
         $httpConfigPath = base_path('docker/nginx/conf.d/app-http.conf');
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
-        
+
         File::ensureDirectoryExists(dirname($httpConfigPath));
         File::put($httpConfigPath, 'http config');
         File::put($httpsConfigPath, 'https config');
-        
+
         // Even with SSL certificates, should use HTTP
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
         File::put(config('laradox.ssl.key_path'), 'dummy key');
@@ -219,11 +219,11 @@ class UpCommandTest extends FeatureTestCase
     {
         $this->createTestDockerComposeFile('production');
         $this->createTestSslDirectory();
-        
+
         // Create nginx configs but NO certificates
         $httpConfigPath = base_path('docker/nginx/conf.d/app-http.conf');
         $httpsConfigPath = base_path('docker/nginx/conf.d/app-https.conf');
-        
+
         File::ensureDirectoryExists(dirname($httpConfigPath));
         File::put($httpConfigPath, 'http config');
         File::put($httpsConfigPath, 'https config');
@@ -248,9 +248,9 @@ class UpCommandTest extends FeatureTestCase
         $this->createTestSslDirectory();
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
         File::put(config('laradox.ssl.key_path'), 'dummy key');
-        
+
         $result = $this->artisan('laradox:up', ['--detach' => true]);
-        
+
         // Command should either succeed with Docker or fail with error message
         $this->assertContains($result->run(), [0, 1]);
     }
@@ -263,11 +263,10 @@ class UpCommandTest extends FeatureTestCase
         $this->createTestSslDirectory();
         File::put(config('laradox.ssl.cert_path'), 'dummy cert');
         File::put(config('laradox.ssl.key_path'), 'dummy key');
-        
+
         $result = $this->artisan('laradox:up', ['--detach' => true]);
-        
+
         // Command should check for Docker Compose availability
         $this->assertContains($result->run(), [0, 1]);
     }
 }
-

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -3,6 +3,7 @@
 namespace Laradox\Tests;
 
 use Illuminate\Support\Facades\File;
+use Throwable;
 
 abstract class FeatureTestCase extends TestCase
 {
@@ -21,7 +22,7 @@ abstract class FeatureTestCase extends TestCase
     {
         // Clean up test artifacts after each test
         $this->cleanupTestFiles();
-        
+
         parent::tearDown();
     }
 
@@ -31,7 +32,7 @@ abstract class FeatureTestCase extends TestCase
     protected function cleanupTestFiles(): void
     {
         try {
-            if (!function_exists('base_path')) {
+            if (! function_exists('base_path')) {
                 return;
             }
 
@@ -54,7 +55,7 @@ abstract class FeatureTestCase extends TestCase
                     }
                 }
             }
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             // Silently catch any errors during cleanup
         }
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -93,11 +93,12 @@ class MyNewTest extends TestCase
 
 ## Dependencies
 
-- PHPUnit ^10.0|^11.0
+- PHPUnit ^10.0|^11.0|^12.0
 - Orchestra Testbench:
   - ^8.0 for Laravel 10.x
   - ^9.0 for Laravel 11.x
   - ^10.0 for Laravel 12.x
+  - ^11.0 for Laravel 13.x
 
 ## Test Matrix
 
@@ -108,6 +109,18 @@ The test suite is tested against multiple PHP and Laravel versions in CI:
 | 10.x | 8.2, 8.3 | ^8.0 |
 | 11.x | 8.2, 8.3, 8.4 | ^9.0 |
 | 12.x | 8.2, 8.3, 8.4 | ^10.0 |
+| 13.x | 8.3, 8.4 | ^11.0 |
+
+> Laravel 13.x requires PHP 8.3 or higher, so the 8.2 combination is intentionally absent.
+
+## Code Style
+
+Code style is enforced with [Laravel Pint](https://laravel.com/docs/pint) and checked in CI:
+
+```bash
+composer lint     # report violations without changing files
+composer format   # apply fixes
+```
 
 All test combinations are tested in GitHub Actions CI/CD pipeline.
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,7 +34,6 @@ abstract class TestCase extends Orchestra
      * Define environment setup.
      *
      * @param  Application  $app
-     * @return void
      */
     protected function defineEnvironment($app): void
     {
@@ -54,7 +53,7 @@ abstract class TestCase extends Orchestra
     protected function createTestDockerComposeFile(string $env = 'development'): string
     {
         $path = base_path("docker-compose.{$env}.yml");
-        $content = <<<YAML
+        $content = <<<'YAML'
 # TEST FILE - DO NOT USE IN PRODUCTION
 # This file is for testing purposes only
 services:
@@ -63,6 +62,7 @@ services:
 YAML;
 
         File::put($path, $content);
+
         return $path;
     }
 
@@ -73,6 +73,7 @@ YAML;
     {
         $path = base_path('docker/nginx/ssl');
         File::makeDirectory($path, 0755, true);
+
         return $path;
     }
 }

--- a/tests/Unit/DockerCheckTest.php
+++ b/tests/Unit/DockerCheckTest.php
@@ -19,7 +19,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_checks_if_docker_is_installed(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function checkDocker(): bool
             {
                 return parent::checkDocker();
@@ -33,7 +34,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_checks_if_docker_compose_is_installed(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function checkDockerCompose(): bool
             {
                 return parent::checkDockerCompose();
@@ -47,7 +49,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_detects_operating_system(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function detectOperatingSystem(): string
             {
                 return parent::detectOperatingSystem();
@@ -61,7 +64,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_detects_linux_os(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function detectOperatingSystem(): string
             {
                 // Simulate Linux detection
@@ -69,6 +73,7 @@ class DockerCheckTest extends TestCase
                 if (stripos($os, 'linux') !== false) {
                     return 'linux';
                 }
+
                 return 'unknown';
             }
         };
@@ -79,7 +84,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_detects_macos_os(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function detectOperatingSystem(): string
             {
                 // Simulate macOS detection
@@ -87,6 +93,7 @@ class DockerCheckTest extends TestCase
                 if (stripos($os, 'darwin') !== false) {
                     return 'macos';
                 }
+
                 return 'unknown';
             }
         };
@@ -97,7 +104,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_detects_windows_os(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function detectOperatingSystem(): string
             {
                 // Simulate Windows detection
@@ -105,6 +113,7 @@ class DockerCheckTest extends TestCase
                 if (stripos($os, 'win') !== false) {
                     return 'windows';
                 }
+
                 return 'unknown';
             }
         };
@@ -115,7 +124,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_checks_if_command_is_available(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function commandAvailable(string $cmd): bool
             {
                 return parent::commandAvailable($cmd);
@@ -320,7 +330,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_opens_browser_on_macos(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public string $executedCommand = '';
 
             public function detectOperatingSystem(): string
@@ -332,7 +343,7 @@ class DockerCheckTest extends TestCase
             {
                 $os = $this->detectOperatingSystem();
                 if ($os === 'macos') {
-                    $this->executedCommand = "open " . escapeshellarg($url);
+                    $this->executedCommand = 'open '.escapeshellarg($url);
                 }
             }
         };
@@ -345,7 +356,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_opens_browser_on_linux(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public string $executedCommand = '';
 
             public function detectOperatingSystem(): string
@@ -357,7 +369,7 @@ class DockerCheckTest extends TestCase
             {
                 $os = $this->detectOperatingSystem();
                 if ($os === 'linux') {
-                    $this->executedCommand = "xdg-open " . escapeshellarg($url) . " 2>/dev/null &";
+                    $this->executedCommand = 'xdg-open '.escapeshellarg($url).' 2>/dev/null &';
                 }
             }
         };
@@ -370,7 +382,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_opens_browser_on_windows(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public string $executedCommand = '';
 
             public function detectOperatingSystem(): string
@@ -382,7 +395,7 @@ class DockerCheckTest extends TestCase
             {
                 $os = $this->detectOperatingSystem();
                 if ($os === 'windows') {
-                    $this->executedCommand = "start " . escapeshellarg($url);
+                    $this->executedCommand = 'start '.escapeshellarg($url);
                 }
             }
         };
@@ -453,7 +466,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_gets_docker_compose_command(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function getDockerComposeCommand(): string
             {
                 return parent::getDockerComposeCommand();
@@ -468,7 +482,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_returns_docker_compose_v2_when_available(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function getDockerComposeCommand(): string
             {
                 // Simulate docker compose v2 being available
@@ -476,6 +491,7 @@ class DockerCheckTest extends TestCase
                 if ($returnCode === 0) {
                     return 'docker compose';
                 }
+
                 return 'docker-compose';
             }
         };
@@ -488,7 +504,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_falls_back_to_docker_compose_v1(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function getDockerComposeCommand(): string
             {
                 // Simulate docker compose v2 NOT being available
@@ -503,7 +520,8 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_checks_docker_compose_with_both_v1_and_v2(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public function checkDockerCompose(): bool
             {
                 return parent::checkDockerCompose();
@@ -595,18 +613,20 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_uses_docker_compose_command_in_are_containers_running(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public string $usedCommand = '';
-            
+
             protected function getDockerComposeCommand(): string
             {
                 return 'docker-compose';
             }
-            
+
             public function areContainersRunning(string $composeFile): bool
             {
                 $dockerCompose = $this->getDockerComposeCommand();
                 $this->usedCommand = $dockerCompose;
+
                 return false; // Just for testing
             }
         };
@@ -618,18 +638,20 @@ class DockerCheckTest extends TestCase
     #[Test]
     public function it_uses_docker_compose_command_in_get_available_services(): void
     {
-        $command = new class extends UpCommand {
+        $command = new class extends UpCommand
+        {
             public string $usedCommand = '';
-            
+
             protected function getDockerComposeCommand(): string
             {
                 return 'docker-compose';
             }
-            
+
             public function getAvailableServices(string $composeFile): array
             {
                 $dockerCompose = $this->getDockerComposeCommand();
                 $this->usedCommand = $dockerCompose;
+
                 return ['nginx', 'php']; // Default for testing
             }
         };

--- a/tests/Unit/DownCommandTest.php
+++ b/tests/Unit/DownCommandTest.php
@@ -2,26 +2,26 @@
 
 namespace Laradox\Tests\Unit;
 
+use Illuminate\Support\Facades\File;
 use Laradox\Console\DownCommand;
 use Laradox\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
-use Illuminate\Support\Facades\File;
 
 class DownCommandTest extends TestCase
 {
     #[Test]
     public function it_has_correct_signature(): void
     {
-        $command = new DownCommand();
-        
+        $command = new DownCommand;
+
         $this->assertStringContainsString('laradox:down', $command->getName());
     }
 
     #[Test]
     public function it_has_environment_option(): void
     {
-        $command = new DownCommand();
-        
+        $command = new DownCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('environment'));
     }
@@ -29,8 +29,8 @@ class DownCommandTest extends TestCase
     #[Test]
     public function it_has_volumes_option(): void
     {
-        $command = new DownCommand();
-        
+        $command = new DownCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('volumes'));
     }
@@ -38,8 +38,8 @@ class DownCommandTest extends TestCase
     #[Test]
     public function it_has_correct_description(): void
     {
-        $command = new DownCommand();
-        
+        $command = new DownCommand;
+
         $this->assertStringContainsString('Stop Laradox Docker containers', $command->getDescription());
     }
 
@@ -48,7 +48,7 @@ class DownCommandTest extends TestCase
     {
         $env = 'development';
         $composePath = base_path("docker-compose.{$env}.yml");
-        
+
         $this->assertStringContainsString('docker-compose.development.yml', $composePath);
     }
 
@@ -57,7 +57,7 @@ class DownCommandTest extends TestCase
     {
         $composeFile = base_path('docker-compose.development.yml');
         $command = sprintf('docker compose -f %s down', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('docker compose', $command);
         $this->assertStringContainsString('down', $command);
     }
@@ -68,7 +68,7 @@ class DownCommandTest extends TestCase
         $composeFile = base_path('docker-compose.development.yml');
         $command = sprintf('docker compose -f %s down', escapeshellarg($composeFile));
         $command .= ' -v';
-        
+
         $this->assertStringContainsString('-v', $command);
     }
 
@@ -77,7 +77,7 @@ class DownCommandTest extends TestCase
     {
         $env = 'development';
         $composeFile = base_path("docker-compose.{$env}.yml");
-        
+
         $this->assertStringContainsString('development', $composeFile);
     }
 
@@ -86,7 +86,7 @@ class DownCommandTest extends TestCase
     {
         $env = 'production';
         $composeFile = base_path("docker-compose.{$env}.yml");
-        
+
         $this->assertStringContainsString('production', $composeFile);
     }
 
@@ -95,7 +95,7 @@ class DownCommandTest extends TestCase
     {
         $composeFile = base_path('docker-compose.development.yml');
         $escaped = escapeshellarg($composeFile);
-        
+
         $this->assertStringStartsWith("'", $escaped);
         $this->assertStringEndsWith("'", $escaped);
     }
@@ -106,7 +106,7 @@ class DownCommandTest extends TestCase
         $composeFile = base_path('docker-compose.development.yml');
         $command = sprintf('docker compose -f %s down', escapeshellarg($composeFile));
         $command .= ' -v';
-        
+
         $expected = sprintf("docker compose -f '%s' down -v", $composeFile);
         $this->assertEquals($expected, $command);
     }
@@ -116,7 +116,7 @@ class DownCommandTest extends TestCase
     {
         $returnCode = 0;
         $result = $returnCode === 0 ? 0 : 1; // SUCCESS : FAILURE
-        
+
         $this->assertEquals(0, $result);
     }
 
@@ -125,7 +125,7 @@ class DownCommandTest extends TestCase
     {
         $returnCode = 1;
         $result = $returnCode === 0 ? 0 : 1; // SUCCESS : FAILURE
-        
+
         $this->assertEquals(1, $result);
     }
 
@@ -134,9 +134,9 @@ class DownCommandTest extends TestCase
     {
         $testFile = base_path('test-file.txt');
         File::put($testFile, 'test');
-        
+
         $this->assertTrue(file_exists($testFile));
-        
+
         File::delete($testFile);
         $this->assertFalse(file_exists($testFile));
     }
@@ -146,7 +146,7 @@ class DownCommandTest extends TestCase
     {
         $developmentEnv = 'development';
         $productionEnv = 'production';
-        
+
         $this->assertEquals('development', $developmentEnv);
         $this->assertEquals('production', $productionEnv);
     }
@@ -154,8 +154,8 @@ class DownCommandTest extends TestCase
     #[Test]
     public function it_has_file_option(): void
     {
-        $command = new DownCommand();
-        
+        $command = new DownCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('file'));
     }
@@ -163,8 +163,8 @@ class DownCommandTest extends TestCase
     #[Test]
     public function it_file_option_has_shortcut_f(): void
     {
-        $command = new DownCommand();
-        
+        $command = new DownCommand;
+
         $definition = $command->getDefinition();
         $option = $definition->getOption('file');
         $this->assertEquals('f', $option->getShortcut());
@@ -176,7 +176,7 @@ class DownCommandTest extends TestCase
         $customFile = 'my-custom-compose.yml';
         $composeFile = base_path($customFile);
         $command = sprintf('docker-compose -f %s down', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('my-custom-compose.yml', $command);
         $this->assertStringContainsString('down', $command);
     }
@@ -185,11 +185,11 @@ class DownCommandTest extends TestCase
     public function it_supports_both_docker_compose_commands(): void
     {
         $composeFile = base_path('docker-compose.development.yml');
-        
+
         // Test with docker compose (V2)
         $commandV2 = sprintf('docker compose -f %s down', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker compose', $commandV2);
-        
+
         // Test with docker-compose (V1)
         $commandV1 = sprintf('docker-compose -f %s down', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker-compose', $commandV1);

--- a/tests/Unit/InstallCommandTest.php
+++ b/tests/Unit/InstallCommandTest.php
@@ -19,16 +19,16 @@ class InstallCommandTest extends TestCase
     #[Test]
     public function it_has_correct_signature(): void
     {
-        $command = new InstallCommand();
-        
+        $command = new InstallCommand;
+
         $this->assertStringContainsString('laradox:install', $command->getName());
     }
 
     #[Test]
     public function it_has_force_option(): void
     {
-        $command = new InstallCommand();
-        
+        $command = new InstallCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('force'));
     }
@@ -36,8 +36,8 @@ class InstallCommandTest extends TestCase
     #[Test]
     public function it_has_correct_description(): void
     {
-        $command = new InstallCommand();
-        
+        $command = new InstallCommand;
+
         $this->assertEquals('Install Laradox Docker environment for Laravel', $command->getDescription());
     }
 
@@ -47,16 +47,16 @@ class InstallCommandTest extends TestCase
         // Create a test script file
         $testPath = base_path('composer');
         File::put($testPath, '#!/bin/bash');
-        
+
         // Make it executable
         chmod($testPath, 0755);
-        
+
         // Check if file is executable
         $perms = fileperms($testPath);
         $isExecutable = ($perms & 0100) !== 0;
-        
+
         $this->assertTrue($isExecutable);
-        
+
         // Cleanup
         File::delete($testPath);
     }
@@ -68,14 +68,14 @@ class InstallCommandTest extends TestCase
         $testPath = base_path('npm');
         File::put($testPath, '#!/bin/bash');
         chmod($testPath, 0644);
-        
+
         // Make it executable
         chmod($testPath, 0755);
         $perms = fileperms($testPath);
         $isExecutable = ($perms & 0100) !== 0;
-        
+
         $this->assertTrue($isExecutable);
-        
+
         // Cleanup
         File::delete($testPath);
     }
@@ -87,14 +87,14 @@ class InstallCommandTest extends TestCase
         $testPath = base_path('php');
         File::put($testPath, '#!/bin/bash');
         chmod($testPath, 0644);
-        
+
         // Make it executable
         chmod($testPath, 0755);
         $perms = fileperms($testPath);
         $isExecutable = ($perms & 0100) !== 0;
-        
+
         $this->assertTrue($isExecutable);
-        
+
         // Cleanup
         File::delete($testPath);
     }
@@ -125,14 +125,14 @@ class InstallCommandTest extends TestCase
             File::put(base_path($script), '#!/bin/bash');
             chmod(base_path($script), 0755);
         }
-        
+
         // Check if all files are executable
         foreach ($scripts as $script) {
             $path = base_path($script);
             $perms = fileperms($path);
             $isExecutable = ($perms & 0100) !== 0;
             $this->assertTrue($isExecutable, "{$script} should be executable");
-            
+
             // Cleanup
             File::delete($path);
         }
@@ -142,7 +142,7 @@ class InstallCommandTest extends TestCase
     public function it_creates_ssl_directory_when_missing(): void
     {
         $sslDir = base_path('docker/nginx/ssl');
-        
+
         // Ensure directory doesn't exist
         if (File::exists($sslDir)) {
             File::deleteDirectory(dirname($sslDir, 2));
@@ -155,12 +155,12 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('comment')->andReturn(null);
         $command->shouldReceive('line')->andReturn(null);
         $command->shouldReceive('option')->with('force')->andReturn(false);
-        
+
         $result = $command->handle();
-        
+
         $this->assertTrue(File::exists($sslDir));
         $this->assertEquals(0, $result);
-        
+
         // Cleanup
         if (File::exists($sslDir)) {
             File::deleteDirectory(dirname($sslDir, 2));
@@ -171,7 +171,7 @@ class InstallCommandTest extends TestCase
     public function it_does_not_fail_when_ssl_directory_exists(): void
     {
         $sslDir = base_path('docker/nginx/ssl');
-        
+
         // Ensure directory exists
         File::makeDirectory($sslDir, 0755, true);
 
@@ -182,12 +182,12 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('comment')->andReturn(null);
         $command->shouldReceive('line')->andReturn(null);
         $command->shouldReceive('option')->with('force')->andReturn(false);
-        
+
         $result = $command->handle();
-        
+
         $this->assertTrue(File::exists($sslDir));
         $this->assertEquals(0, $result);
-        
+
         // Cleanup
         if (File::exists($sslDir)) {
             File::deleteDirectory(dirname($sslDir, 2));
@@ -212,9 +212,9 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('makeScriptsExecutable')->andReturn(null);
-        
+
         $result = $command->handle();
-        
+
         $this->assertEquals(0, $result);
     }
 
@@ -236,9 +236,9 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('option')->with('force')->andReturn(true);
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('makeScriptsExecutable')->andReturn(null);
-        
+
         $result = $command->handle();
-        
+
         $this->assertEquals(0, $result);
     }
 
@@ -254,9 +254,9 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('makeScriptsExecutable')->andReturn(null);
-        
+
         $result = $command->handle();
-        
+
         $this->assertEquals(0, $result);
     }
 
@@ -272,9 +272,9 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('makeScriptsExecutable')->andReturn(null);
-        
+
         $command->handle();
-        
+
         // If we get here without exception, the test passes
         $this->assertTrue(true);
     }
@@ -294,9 +294,9 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('makeScriptsExecutable')->andReturn(null);
-        
+
         $command->handle();
-        
+
         $this->assertTrue(true);
     }
 
@@ -315,9 +315,9 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('option')->with('force')->andReturn(false);
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('makeScriptsExecutable')->andReturn(null);
-        
+
         $command->handle();
-        
+
         $this->assertTrue(true);
     }
 
@@ -328,14 +328,14 @@ class InstallCommandTest extends TestCase
         $testPath = base_path('composer');
         File::put($testPath, '#!/bin/bash');
         chmod($testPath, 0644); // Remove execute permission first
-        
+
         // Set to 0755
         chmod($testPath, 0755);
-        
+
         // Check if permissions are set to 0755
         $perms = fileperms($testPath) & 0777;
         $this->assertEquals(0755, $perms);
-        
+
         // Cleanup
         File::delete($testPath);
     }
@@ -344,7 +344,7 @@ class InstallCommandTest extends TestCase
     public function it_creates_ssl_directory_with_correct_permissions(): void
     {
         $sslDir = base_path('docker/nginx/ssl');
-        
+
         // Ensure directory doesn't exist
         if (File::exists($sslDir)) {
             File::deleteDirectory(dirname($sslDir, 2));
@@ -357,15 +357,15 @@ class InstallCommandTest extends TestCase
         $command->shouldReceive('comment')->andReturn(null);
         $command->shouldReceive('line')->andReturn(null);
         $command->shouldReceive('option')->with('force')->andReturn(false);
-        
+
         $command->handle();
-        
+
         $this->assertTrue(File::exists($sslDir));
-        
+
         // Check permissions
         $perms = fileperms($sslDir) & 0777;
         $this->assertEquals(0755, $perms);
-        
+
         // Cleanup
         if (File::exists($sslDir)) {
             File::deleteDirectory(dirname($sslDir, 2));

--- a/tests/Unit/LaradoxServiceProviderTest.php
+++ b/tests/Unit/LaradoxServiceProviderTest.php
@@ -52,7 +52,7 @@ class LaradoxServiceProviderTest extends TestCase
     public function it_has_publishable_config(): void
     {
         $provider = new LaradoxServiceProvider($this->app);
-        
+
         // The provider registers publishable assets
         $this->assertInstanceOf(LaradoxServiceProvider::class, $provider);
     }

--- a/tests/Unit/LogsCommandTest.php
+++ b/tests/Unit/LogsCommandTest.php
@@ -11,27 +11,27 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_has_correct_signature(): void
     {
-        $command = new LogsCommand();
-        
+        $command = new LogsCommand;
+
         $this->assertStringContainsString('laradox:logs', $command->getName());
     }
 
     #[Test]
     public function it_has_correct_description(): void
     {
-        $command = new LogsCommand();
-        
+        $command = new LogsCommand;
+
         $this->assertEquals('View Laradox Docker container logs', $command->getDescription());
     }
 
     #[Test]
     public function it_accepts_service_argument(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasArgument('service'));
-        
+
         $argument = $definition->getArgument('service');
         $this->assertFalse($argument->isRequired());
     }
@@ -39,11 +39,11 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_has_environment_option(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasOption('environment'));
-        
+
         $option = $definition->getOption('environment');
         $this->assertEquals('development', $option->getDefault());
     }
@@ -51,20 +51,20 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_has_follow_option(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasOption('follow'));
     }
 
     #[Test]
     public function it_has_tail_option(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasOption('tail'));
-        
+
         $option = $definition->getOption('tail');
         $this->assertTrue($option->acceptValue());
     }
@@ -72,21 +72,21 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_has_timestamps_option(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasOption('timestamps'));
     }
 
     #[Test]
     public function it_validates_all_required_options_are_present(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         // Verify all expected options exist (excluding default Laravel command options)
         $expectedOptions = ['environment', 'follow', 'tail', 'timestamps'];
-        
+
         foreach ($expectedOptions as $option) {
             $this->assertTrue(
                 $definition->hasOption($option),
@@ -98,11 +98,11 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_has_service_argument_as_optional(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasArgument('service'));
-        
+
         $argument = $definition->getArgument('service');
         $this->assertFalse($argument->isRequired(), 'Service argument should be optional');
     }
@@ -110,9 +110,9 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_has_shortcut_for_follow_option(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('follow');
         $this->assertEquals('f', $option->getShortcut());
     }
@@ -120,17 +120,17 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_extends_illuminate_command(): void
     {
-        $command = new LogsCommand();
-        
+        $command = new LogsCommand;
+
         $this->assertInstanceOf(\Illuminate\Console\Command::class, $command);
     }
 
     #[Test]
     public function environment_option_accepts_values(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('environment');
         $this->assertTrue($option->acceptValue());
     }
@@ -138,9 +138,9 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function tail_option_accepts_numeric_values(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('tail');
         $this->assertTrue($option->acceptValue());
     }
@@ -148,9 +148,9 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function timestamps_option_is_boolean(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('timestamps');
         $this->assertFalse($option->acceptValue());
     }
@@ -158,9 +158,9 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function follow_option_is_boolean(): void
     {
-        $command = new LogsCommand();
+        $command = new LogsCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('follow');
         $this->assertFalse($option->acceptValue());
     }
@@ -168,8 +168,8 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_has_file_option(): void
     {
-        $command = new LogsCommand();
-        
+        $command = new LogsCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('file'));
     }
@@ -177,8 +177,8 @@ class LogsCommandTest extends TestCase
     #[Test]
     public function it_file_option_accepts_value(): void
     {
-        $command = new LogsCommand();
-        
+        $command = new LogsCommand;
+
         $definition = $command->getDefinition();
         $option = $definition->getOption('file');
         $this->assertTrue($option->acceptValue());
@@ -190,7 +190,7 @@ class LogsCommandTest extends TestCase
         $customFile = 'my-custom-compose.yml';
         $composeFile = base_path($customFile);
         $command = sprintf('docker-compose -f %s logs', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('my-custom-compose.yml', $command);
         $this->assertStringContainsString('logs', $command);
     }
@@ -199,11 +199,11 @@ class LogsCommandTest extends TestCase
     public function it_supports_both_docker_compose_commands(): void
     {
         $composeFile = base_path('docker-compose.development.yml');
-        
+
         // Test with docker compose (V2)
         $commandV2 = sprintf('docker compose -f %s logs', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker compose', $commandV2);
-        
+
         // Test with docker-compose (V1)
         $commandV1 = sprintf('docker-compose -f %s logs', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker-compose', $commandV1);

--- a/tests/Unit/SetupSSLCommandTest.php
+++ b/tests/Unit/SetupSSLCommandTest.php
@@ -18,7 +18,8 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_detects_linux_operating_system(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public function detectOS(): string
             {
                 return parent::detectOS();
@@ -33,7 +34,8 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_detects_macos_operating_system(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public function detectOS(): string
             {
                 // Override to test macOS detection
@@ -41,6 +43,7 @@ class SetupSSLCommandTest extends TestCase
                 if (stripos($os, 'darwin') !== false) {
                     return 'macos';
                 }
+
                 return 'unknown';
             }
         };
@@ -51,7 +54,8 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_detects_windows_operating_system(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public function detectOS(): string
             {
                 // Override to test Windows detection
@@ -59,6 +63,7 @@ class SetupSSLCommandTest extends TestCase
                 if (stripos($os, 'win') !== false) {
                     return 'windows';
                 }
+
                 return 'unknown';
             }
         };
@@ -69,7 +74,8 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_checks_if_mkcert_command_exists(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public function checkMkcert(): bool
             {
                 return parent::checkMkcert();
@@ -83,7 +89,8 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_checks_if_command_exists(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public function commandExists(string $cmd): bool
             {
                 return parent::commandExists($cmd);
@@ -174,7 +181,7 @@ class SetupSSLCommandTest extends TestCase
             ->with('yum')->andReturn(false)
             ->shouldReceive('commandExists')
             ->with('dnf')->andReturn(false);
-        
+
         $command->shouldReceive('info')->andReturn(null);
         $command->shouldReceive('newLine')->andReturn(null);
         $command->shouldReceive('error')->andReturn(null);
@@ -192,7 +199,7 @@ class SetupSSLCommandTest extends TestCase
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('commandExists')
             ->with('apt-get')->andReturn(true);
-        
+
         $hasApt = $command->commandExists('apt-get');
         $this->assertTrue($hasApt);
     }
@@ -206,10 +213,10 @@ class SetupSSLCommandTest extends TestCase
             ->with('apt-get')->andReturn(false)
             ->shouldReceive('commandExists')
             ->with('dnf')->andReturn(true);
-        
+
         $hasApt = $command->commandExists('apt-get');
         $hasDnf = $command->commandExists('dnf');
-        
+
         $this->assertFalse($hasApt);
         $this->assertTrue($hasDnf);
     }
@@ -223,10 +230,10 @@ class SetupSSLCommandTest extends TestCase
             ->with('apt-get')->andReturn(false)
             ->shouldReceive('commandExists')
             ->with('yum')->andReturn(true);
-        
+
         $hasApt = $command->commandExists('apt-get');
         $hasYum = $command->commandExists('yum');
-        
+
         $this->assertFalse($hasApt);
         $this->assertTrue($hasYum);
     }
@@ -238,7 +245,7 @@ class SetupSSLCommandTest extends TestCase
         $command->shouldAllowMockingProtectedMethods();
         $command->shouldReceive('commandExists')
             ->with('brew')->andReturn(false);
-        
+
         $command->shouldReceive('error')->andReturn(null);
         $command->shouldReceive('line')->andReturn(null);
 
@@ -250,19 +257,20 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_opens_url_on_macos(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public string $executedCommand = '';
-            
+
             public function detectOS(): string
             {
                 return 'macos';
             }
-            
+
             public function openURL(string $url): void
             {
                 $os = $this->detectOS();
                 if ($os === 'macos') {
-                    $this->executedCommand = "open " . escapeshellarg($url);
+                    $this->executedCommand = 'open '.escapeshellarg($url);
                 }
             }
         };
@@ -275,19 +283,20 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_opens_url_on_linux(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public string $executedCommand = '';
-            
+
             public function detectOS(): string
             {
                 return 'linux';
             }
-            
+
             public function openURL(string $url): void
             {
                 $os = $this->detectOS();
                 if ($os === 'linux') {
-                    $this->executedCommand = "xdg-open " . escapeshellarg($url);
+                    $this->executedCommand = 'xdg-open '.escapeshellarg($url);
                 }
             }
         };
@@ -300,19 +309,20 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_opens_url_on_windows(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public string $executedCommand = '';
-            
+
             public function detectOS(): string
             {
                 return 'windows';
             }
-            
+
             public function openURL(string $url): void
             {
                 $os = $this->detectOS();
                 if ($os === 'windows') {
-                    $this->executedCommand = "start " . escapeshellarg($url);
+                    $this->executedCommand = 'start '.escapeshellarg($url);
                 }
             }
         };
@@ -325,26 +335,27 @@ class SetupSSLCommandTest extends TestCase
     #[Test]
     public function it_escapes_url_properly(): void
     {
-        $command = new class extends SetupSSLCommand {
+        $command = new class extends SetupSSLCommand
+        {
             public string $executedCommand = '';
-            
+
             public function detectOS(): string
             {
                 return 'macos';
             }
-            
+
             public function openURL(string $url): void
             {
                 $os = $this->detectOS();
                 if ($os === 'macos') {
-                    $this->executedCommand = "open " . escapeshellarg($url);
+                    $this->executedCommand = 'open '.escapeshellarg($url);
                 }
             }
         };
 
         $urlWithSpecialChars = 'https://example.com/path?param=value&other=test';
         $command->openURL($urlWithSpecialChars);
-        
+
         $this->assertStringContainsString('open', $command->executedCommand);
     }
 

--- a/tests/Unit/ShellCommandTest.php
+++ b/tests/Unit/ShellCommandTest.php
@@ -11,27 +11,27 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_correct_signature(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $this->assertStringContainsString('laradox:shell', $command->getName());
     }
 
     #[Test]
     public function it_has_correct_description(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $this->assertEquals('Enter a container interactively', $command->getDescription());
     }
 
     #[Test]
     public function it_accepts_service_argument(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasArgument('service'));
-        
+
         $argument = $definition->getArgument('service');
         $this->assertFalse($argument->isRequired());
         $this->assertEquals('php', $argument->getDefault());
@@ -40,11 +40,11 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_environment_option(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasOption('environment'));
-        
+
         $option = $definition->getOption('environment');
         $this->assertEquals('development', $option->getDefault());
     }
@@ -52,11 +52,11 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_user_option(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasOption('user'));
-        
+
         $option = $definition->getOption('user');
         $this->assertTrue($option->acceptValue());
     }
@@ -64,11 +64,11 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_shell_option(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasOption('shell'));
-        
+
         $option = $definition->getOption('shell');
         $this->assertEquals('sh', $option->getDefault());
     }
@@ -76,12 +76,12 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_validates_all_required_options_are_present(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         // Verify all expected options exist
         $expectedOptions = ['environment', 'user', 'shell'];
-        
+
         foreach ($expectedOptions as $option) {
             $this->assertTrue(
                 $definition->hasOption($option),
@@ -93,11 +93,11 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_service_argument_with_default_value(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $this->assertTrue($definition->hasArgument('service'));
-        
+
         $argument = $definition->getArgument('service');
         $this->assertEquals('php', $argument->getDefault());
     }
@@ -105,17 +105,17 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_extends_illuminate_command(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $this->assertInstanceOf(\Illuminate\Console\Command::class, $command);
     }
 
     #[Test]
     public function environment_option_accepts_values(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('environment');
         $this->assertTrue($option->acceptValue());
     }
@@ -123,9 +123,9 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function user_option_is_optional(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('user');
         $this->assertNull($option->getDefault());
     }
@@ -133,9 +133,9 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function shell_option_has_sh_default(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $option = $definition->getOption('shell');
         $this->assertEquals('sh', $option->getDefault());
     }
@@ -143,9 +143,9 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function service_argument_defaults_to_php(): void
     {
-        $command = new ShellCommand();
+        $command = new ShellCommand;
         $definition = $command->getDefinition();
-        
+
         $argument = $definition->getArgument('service');
         $this->assertEquals('php', $argument->getDefault());
     }
@@ -153,8 +153,8 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_uses_checks_docker_trait(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $this->assertTrue(
             method_exists($command, 'checkDocker'),
             'ShellCommand should use ChecksDocker trait'
@@ -164,8 +164,8 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_is_service_running_method(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $this->assertTrue(
             method_exists($command, 'isServiceRunning'),
             'ShellCommand should have isServiceRunning method'
@@ -175,8 +175,8 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_detect_available_shell_method(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $this->assertTrue(
             method_exists($command, 'detectAvailableShell'),
             'ShellCommand should have detectAvailableShell method'
@@ -186,8 +186,8 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_has_file_option(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('file'));
     }
@@ -195,8 +195,8 @@ class ShellCommandTest extends TestCase
     #[Test]
     public function it_file_option_has_shortcut_f(): void
     {
-        $command = new ShellCommand();
-        
+        $command = new ShellCommand;
+
         $definition = $command->getDefinition();
         $option = $definition->getOption('file');
         $this->assertEquals('f', $option->getShortcut());
@@ -208,7 +208,7 @@ class ShellCommandTest extends TestCase
         $customFile = 'my-custom-compose.yml';
         $composeFile = base_path($customFile);
         $command = sprintf('docker-compose -f %s exec', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('my-custom-compose.yml', $command);
         $this->assertStringContainsString('exec', $command);
     }
@@ -217,11 +217,11 @@ class ShellCommandTest extends TestCase
     public function it_supports_both_docker_compose_commands(): void
     {
         $composeFile = base_path('docker-compose.development.yml');
-        
+
         // Test with docker compose (V2)
         $commandV2 = sprintf('docker compose -f %s exec', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker compose', $commandV2);
-        
+
         // Test with docker-compose (V1)
         $commandV1 = sprintf('docker-compose -f %s exec', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker-compose', $commandV1);
@@ -231,10 +231,10 @@ class ShellCommandTest extends TestCase
     public function it_constructs_ps_command_with_docker_compose(): void
     {
         $composeFile = base_path('docker-compose.development.yml');
-        
+
         $commandV1 = sprintf('docker-compose -f %s ps --services --filter "status=running"', escapeshellarg($composeFile));
         $this->assertStringContainsString('ps --services', $commandV1);
-        
+
         $commandV2 = sprintf('docker compose -f %s ps --services --filter "status=running"', escapeshellarg($composeFile));
         $this->assertStringContainsString('ps --services', $commandV2);
     }

--- a/tests/Unit/UpCommandTest.php
+++ b/tests/Unit/UpCommandTest.php
@@ -2,27 +2,26 @@
 
 namespace Laradox\Tests\Unit;
 
+use Illuminate\Support\Facades\Config;
 use Laradox\Console\UpCommand;
 use Laradox\Tests\TestCase;
 use PHPUnit\Framework\Attributes\Test;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Config;
 
 class UpCommandTest extends TestCase
 {
     #[Test]
     public function it_has_correct_signature(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $this->assertStringContainsString('laradox:up', $command->getName());
     }
 
     #[Test]
     public function it_has_environment_option(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('environment'));
     }
@@ -30,8 +29,8 @@ class UpCommandTest extends TestCase
     #[Test]
     public function it_has_detach_option(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('detach'));
     }
@@ -39,8 +38,8 @@ class UpCommandTest extends TestCase
     #[Test]
     public function it_has_build_option(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('build'));
     }
@@ -48,8 +47,8 @@ class UpCommandTest extends TestCase
     #[Test]
     public function it_has_force_ssl_option(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('force-ssl'));
     }
@@ -57,8 +56,8 @@ class UpCommandTest extends TestCase
     #[Test]
     public function it_has_correct_description(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $this->assertStringContainsString('Start Laradox Docker containers', $command->getDescription());
     }
 
@@ -67,7 +66,7 @@ class UpCommandTest extends TestCase
     {
         $env = 'development';
         $composePath = base_path("docker-compose.{$env}.yml");
-        
+
         $this->assertStringContainsString('docker-compose.development.yml', $composePath);
     }
 
@@ -76,10 +75,10 @@ class UpCommandTest extends TestCase
     {
         Config::set('laradox.ssl.cert_path', base_path('docker/nginx/ssl/localhost.pem'));
         Config::set('laradox.ssl.key_path', base_path('docker/nginx/ssl/localhost-key.pem'));
-        
+
         $certPath = config('laradox.ssl.cert_path');
         $keyPath = config('laradox.ssl.key_path');
-        
+
         $this->assertStringContainsString('localhost.pem', $certPath);
         $this->assertStringContainsString('localhost-key.pem', $keyPath);
     }
@@ -90,7 +89,7 @@ class UpCommandTest extends TestCase
         $httpConfig = base_path('docker/nginx/conf.d/app-http.conf');
         $httpsConfig = base_path('docker/nginx/conf.d/app-https.conf');
         $targetConfig = base_path('docker/nginx/conf.d/app.conf');
-        
+
         $this->assertIsString($httpConfig);
         $this->assertIsString($httpsConfig);
         $this->assertIsString($targetConfig);
@@ -101,7 +100,7 @@ class UpCommandTest extends TestCase
     {
         $composeFile = base_path('docker-compose.development.yml');
         $command = sprintf('docker compose -f %s up', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('docker compose', $command);
         $this->assertStringContainsString('up', $command);
     }
@@ -112,7 +111,7 @@ class UpCommandTest extends TestCase
         $composeFile = base_path('docker-compose.development.yml');
         $command = sprintf('docker compose -f %s up', escapeshellarg($composeFile));
         $command .= ' --build';
-        
+
         $this->assertStringContainsString('--build', $command);
     }
 
@@ -122,7 +121,7 @@ class UpCommandTest extends TestCase
         $composeFile = base_path('docker-compose.development.yml');
         $command = sprintf('docker compose -f %s up', escapeshellarg($composeFile));
         $command .= ' -d';
-        
+
         $this->assertStringContainsString('-d', $command);
     }
 
@@ -131,7 +130,7 @@ class UpCommandTest extends TestCase
     {
         $env = 'development';
         $composeFile = base_path("docker-compose.{$env}.yml");
-        
+
         $this->assertStringContainsString('development', $composeFile);
     }
 
@@ -140,7 +139,7 @@ class UpCommandTest extends TestCase
     {
         $composeFile = base_path('docker-compose.development.yml');
         $restartCommand = sprintf('docker compose -f %s restart', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('docker compose', $restartCommand);
         $this->assertStringContainsString('restart', $restartCommand);
     }
@@ -150,7 +149,7 @@ class UpCommandTest extends TestCase
     {
         $composeFile = base_path('docker-compose.development.yml');
         $command = sprintf('docker compose -f %s ps --quiet 2>/dev/null', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('ps --quiet', $command);
     }
 
@@ -159,9 +158,9 @@ class UpCommandTest extends TestCase
     {
         $sslExists = true;
         $forceSsl = null;
-        
+
         $protocol = $sslExists && $forceSsl !== 'false' ? 'https' : 'http';
-        
+
         $this->assertEquals('https', $protocol);
     }
 
@@ -170,9 +169,9 @@ class UpCommandTest extends TestCase
     {
         $sslExists = false;
         $forceSsl = 'false';
-        
+
         $protocol = $sslExists && $forceSsl !== 'false' ? 'https' : 'http';
-        
+
         $this->assertEquals('http', $protocol);
     }
 
@@ -181,7 +180,7 @@ class UpCommandTest extends TestCase
     {
         $forceSslTrue = filter_var('true', FILTER_VALIDATE_BOOLEAN);
         $forceSslFalse = filter_var('false', FILTER_VALIDATE_BOOLEAN);
-        
+
         $this->assertTrue($forceSslTrue);
         $this->assertFalse($forceSslFalse);
     }
@@ -191,7 +190,7 @@ class UpCommandTest extends TestCase
     {
         $composeFile = base_path('docker-compose.development.yml');
         $escaped = escapeshellarg($composeFile);
-        
+
         $this->assertStringStartsWith("'", $escaped);
         $this->assertStringEndsWith("'", $escaped);
     }
@@ -201,7 +200,7 @@ class UpCommandTest extends TestCase
     {
         $httpsConfig = 'app-https.conf';
         $httpConfig = 'app-http.conf';
-        
+
         $this->assertEquals('app-https.conf', $httpsConfig);
         $this->assertEquals('app-http.conf', $httpConfig);
     }
@@ -209,8 +208,8 @@ class UpCommandTest extends TestCase
     #[Test]
     public function it_has_file_option(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $definition = $command->getDefinition();
         $this->assertTrue($definition->hasOption('file'));
     }
@@ -218,8 +217,8 @@ class UpCommandTest extends TestCase
     #[Test]
     public function it_file_option_has_shortcut_f(): void
     {
-        $command = new UpCommand();
-        
+        $command = new UpCommand;
+
         $definition = $command->getDefinition();
         $option = $definition->getOption('file');
         $this->assertEquals('f', $option->getShortcut());
@@ -231,7 +230,7 @@ class UpCommandTest extends TestCase
         $customFile = 'my-custom-compose.yml';
         $composeFile = base_path($customFile);
         $command = sprintf('docker-compose -f %s up', escapeshellarg($composeFile));
-        
+
         $this->assertStringContainsString('my-custom-compose.yml', $command);
         $this->assertStringContainsString('up', $command);
     }
@@ -240,11 +239,11 @@ class UpCommandTest extends TestCase
     public function it_supports_both_docker_compose_commands(): void
     {
         $composeFile = base_path('docker-compose.development.yml');
-        
+
         // Test with docker compose (V2)
         $commandV2 = sprintf('docker compose -f %s up', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker compose', $commandV2);
-        
+
         // Test with docker-compose (V1)
         $commandV1 = sprintf('docker-compose -f %s up', escapeshellarg($composeFile));
         $this->assertStringContainsString('docker-compose', $commandV1);
@@ -254,10 +253,10 @@ class UpCommandTest extends TestCase
     public function it_constructs_restart_command_with_docker_compose(): void
     {
         $composeFile = base_path('docker-compose.development.yml');
-        
+
         $commandV1 = sprintf('docker-compose -f %s restart', escapeshellarg($composeFile));
         $this->assertStringContainsString('restart', $commandV1);
-        
+
         $commandV2 = sprintf('docker compose -f %s restart', escapeshellarg($composeFile));
         $this->assertStringContainsString('restart', $commandV2);
     }


### PR DESCRIPTION
Add Laravel 13.x to the supported range and modernise the FrankenPHP image, fixing several runtime bugs found along the way.

Laravel 13:
- Allow ^13.0 for illuminate/console and illuminate/support
- Accept orchestra/testbench ^11.0 and phpunit/phpunit ^12.0
- Cover Laravel 13 on PHP 8.3 and 8.4 in CI (13.x requires PHP >= 8.3)

Fixes:
- Production containers no longer start Octane with --watch. The environment check lived in CMD, which the container shell evaluates at runtime and so could never see the ENVIRONMENT build arg; every container took the development branch. CMD is now defined per build stage.
- Bind Octane to 0.0.0.0 instead of its 127.0.0.1 default, so nginx can actually reach the php service.
- Drop the leading colon from LARADOX_FRANKENPHP_PORT, which produced an invalid --port=:8080, and template the nginx upstream from the same variable instead of hardcoding php:8080.
- Resolve supercronic by TARGETARCH so the image builds on arm64.
- Pass LARADOX_USER_ID/LARADOX_GROUP_ID through to the build; the USER_ID/GROUP_ID args previously always fell back to 1000.
- Point COMPOSER_HOME/COMPOSER_CACHE_DIR at the paths the development compose file mounts, so the host cache and auth.json are used.

Image changes:
- FrankenPHP 1.7 -> 1.12, supercronic 0.2.29 -> 0.2.48, with FRANKENPHP_VERSION, PHP_VERSION and SUPERCRONIC_VERSION build args
- Add pdo_mysql; build gd with JPEG, WebP and FreeType support
- Tune OPcache per environment: validate timestamps in development so --watch reloads work, tracing JIT with validation off in production
- Consolidate builder layers and drop build packages whose extensions already ship with the base image (mbstring, libxml2, oniguruma, curl-dev); the redundant mbstring build was also loading the module twice
- Wrap CMD in sh -c exec so PHP is PID 1 and SIGTERM reaches Octane

Tooling:
- Add laravel/pint with composer lint/format scripts and a CI job, and apply it across src/ and tests/
- Move coverage reporting from phpunit.xml to the CI command, so local runs no longer need a coverage driver

Both build targets were built and inspected to verify the image config, and the nginx template was rendered in a container to confirm the port substitutes while nginx runtime variables survive envsubst.